### PR TITLE
Discard master/slave vocabulary

### DIFF
--- a/chroot/usr/lib/python2.7/distutils/command/install.py
+++ b/chroot/usr/lib/python2.7/distutils/command/install.py
@@ -260,7 +260,7 @@ class install (Command):
 
     def finalize_options (self):
 
-        # This method (and its pliant slaves, like 'finalize_unix()',
+        # This method (and its pliant subordinates, like 'finalize_unix()',
         # 'finalize_other()', and 'select_scheme()') is where the default
         # installation directories for modules, extension modules, and
         # anything else we care to install from a Python module

--- a/chroot/usr/lib/python2.7/doctest.py
+++ b/chroot/usr/lib/python2.7/doctest.py
@@ -1458,7 +1458,7 @@ class DocTestRunner:
         return TestResults(totalf, totalt)
 
     #/////////////////////////////////////////////////////////////////
-    # Backward compatibility cruft to maintain doctest.master.
+    # Backward compatibility cruft to maintain doctest.main.
     #/////////////////////////////////////////////////////////////////
     def merge(self, other):
         d = self._name2ft
@@ -1754,7 +1754,7 @@ class DebugRunner(DocTestRunner):
 
 # For backward compatibility, a global instance of a DocTestRunner
 # class, updated by testmod.
-master = None
+main = None
 
 def testmod(m=None, name=None, globs=None, verbose=None,
             report=True, optionflags=0, extraglobs=None,
@@ -1816,13 +1816,13 @@ def testmod(m=None, name=None, globs=None, verbose=None,
 
     Advanced tomfoolery:  testmod runs methods of a local instance of
     class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
+    global Tester instance doctest.main.  Methods of doctest.main
     can be called directly too, if you want to do something unusual.
     Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
+    displaying a summary.  Invoke doctest.main.summarize(verbose)
     when you're done fiddling.
     """
-    global master
+    global main
 
     # If no module was given, then use __main__.
     if m is None:
@@ -1853,10 +1853,10 @@ def testmod(m=None, name=None, globs=None, verbose=None,
     if report:
         runner.summarize()
 
-    if master is None:
-        master = runner
+    if main is None:
+        main = runner
     else:
-        master.merge(runner)
+        main.merge(runner)
 
     return TestResults(runner.failures, runner.tries)
 
@@ -1934,13 +1934,13 @@ def testfile(filename, module_relative=True, name=None, package=None,
 
     Advanced tomfoolery:  testmod runs methods of a local instance of
     class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
+    global Tester instance doctest.main.  Methods of doctest.main
     can be called directly too, if you want to do something unusual.
     Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
+    displaying a summary.  Invoke doctest.main.summarize(verbose)
     when you're done fiddling.
     """
-    global master
+    global main
 
     if package and not module_relative:
         raise ValueError("Package may only be specified for module-"
@@ -1978,10 +1978,10 @@ def testfile(filename, module_relative=True, name=None, package=None,
     if report:
         runner.summarize()
 
-    if master is None:
-        master = runner
+    if main is None:
+        main = runner
     else:
-        master.merge(runner)
+        main.merge(runner)
 
     return TestResults(runner.failures, runner.tries)
 

--- a/chroot/usr/lib/python2.7/gettext.py
+++ b/chroot/usr/lib/python2.7/gettext.py
@@ -272,17 +272,17 @@ class GNUTranslations(NullTranslations):
         # Are we big endian or little endian?
         magic = unpack('<I', buf[:4])[0]
         if magic == self.LE_MAGIC:
-            version, msgcount, masteridx, transidx = unpack('<4I', buf[4:20])
+            version, msgcount, mainidx, transidx = unpack('<4I', buf[4:20])
             ii = '<II'
         elif magic == self.BE_MAGIC:
-            version, msgcount, masteridx, transidx = unpack('>4I', buf[4:20])
+            version, msgcount, mainidx, transidx = unpack('>4I', buf[4:20])
             ii = '>II'
         else:
             raise IOError(0, 'Bad magic number', filename)
         # Now put all messages from the .mo file buffer into the catalog
         # dictionary.
         for i in xrange(0, msgcount):
-            mlen, moff = unpack(ii, buf[masteridx:masteridx+8])
+            mlen, moff = unpack(ii, buf[mainidx:mainidx+8])
             mend = moff + mlen
             tlen, toff = unpack(ii, buf[transidx:transidx+8])
             tend = toff + tlen
@@ -337,7 +337,7 @@ class GNUTranslations(NullTranslations):
                     tmsg = unicode(tmsg, self._charset)
                 catalog[msg] = tmsg
             # advance to next entry in the seek tables
-            masteridx += 8
+            mainidx += 8
             transidx += 8
 
     def gettext(self, message):

--- a/chroot/usr/lib/python2.7/lib-tk/Dialog.py
+++ b/chroot/usr/lib/python2.7/lib-tk/Dialog.py
@@ -10,10 +10,10 @@ else:
 
 
 class Dialog(Widget):
-    def __init__(self, master=None, cnf={}, **kw):
+    def __init__(self, main=None, cnf={}, **kw):
         cnf = _cnfmerge((cnf, kw))
         self.widgetName = '__dialog__'
-        Widget._setup(self, master, cnf)
+        Widget._setup(self, main, cnf)
         self.num = self.tk.getint(
                 self.tk.call(
                       'tk_dialog', self._w,

--- a/chroot/usr/lib/python2.7/lib-tk/FileDialog.py
+++ b/chroot/usr/lib/python2.7/lib-tk/FileDialog.py
@@ -24,7 +24,7 @@ class FileDialog:
 
     Usage:
 
-        d = FileDialog(master)
+        d = FileDialog(main)
         fname = d.go(dir_or_file, pattern, default, key)
         if fname is None: ...canceled...
         else: ...open file...
@@ -43,12 +43,12 @@ class FileDialog:
 
     title = "File Selection Dialog"
 
-    def __init__(self, master, title=None):
+    def __init__(self, main, title=None):
         if title is None: title = self.title
-        self.master = master
+        self.main = main
         self.directory = None
 
-        self.top = Toplevel(master)
+        self.top = Toplevel(main)
         self.top.title(title)
         self.top.iconname(title)
 
@@ -122,7 +122,7 @@ class FileDialog:
         self.top.wait_visibility() # window needs to be visible for the grab
         self.top.grab_set()
         self.how = None
-        self.master.mainloop()          # Exited by self.quit(how)
+        self.main.mainloop()          # Exited by self.quit(how)
         if key:
             directory, pattern = self.get_filter()
             if self.how:
@@ -133,7 +133,7 @@ class FileDialog:
 
     def quit(self, how=None):
         self.how = how
-        self.master.quit()              # Exit mainloop()
+        self.main.quit()              # Exit mainloop()
 
     def dirs_double_event(self, event):
         self.filter_command()
@@ -162,7 +162,7 @@ class FileDialog:
         try:
             names = os.listdir(dir)
         except os.error:
-            self.master.bell()
+            self.main.bell()
             return
         self.directory = dir
         self.set_filter(dir, pat)
@@ -226,7 +226,7 @@ class LoadFileDialog(FileDialog):
     def ok_command(self):
         file = self.get_selection()
         if not os.path.isfile(file):
-            self.master.bell()
+            self.main.bell()
         else:
             self.quit(file)
 
@@ -241,7 +241,7 @@ class SaveFileDialog(FileDialog):
         file = self.get_selection()
         if os.path.exists(file):
             if os.path.isdir(file):
-                self.master.bell()
+                self.main.bell()
                 return
             d = Dialog(self.top,
                        title="Overwrite Existing File Question",
@@ -254,7 +254,7 @@ class SaveFileDialog(FileDialog):
         else:
             head, tail = os.path.split(file)
             if not os.path.isdir(head):
-                self.master.bell()
+                self.main.bell()
                 return
         self.quit(file)
 

--- a/chroot/usr/lib/python2.7/lib-tk/ScrolledText.py
+++ b/chroot/usr/lib/python2.7/lib-tk/ScrolledText.py
@@ -5,7 +5,7 @@ automatically when not needed, to move them to the other side of the
 window, etc.)
 
 Configuration options are passed to the Text widget.
-A Frame widget is inserted between the master and the text, to hold
+A Frame widget is inserted between the main and the text, to hold
 the Scrollbar widget.
 Most methods calls are inherited from the Text widget; Pack, Grid and
 Place methods are redirected to the Frame widget however.
@@ -17,8 +17,8 @@ from Tkinter import Frame, Text, Scrollbar, Pack, Grid, Place
 from Tkconstants import RIGHT, LEFT, Y, BOTH
 
 class ScrolledText(Text):
-    def __init__(self, master=None, **kw):
-        self.frame = Frame(master)
+    def __init__(self, main=None, **kw):
+        self.frame = Frame(main)
         self.vbar = Scrollbar(self.frame)
         self.vbar.pack(side=RIGHT, fill=Y)
 

--- a/chroot/usr/lib/python2.7/lib-tk/SimpleDialog.py
+++ b/chroot/usr/lib/python2.7/lib-tk/SimpleDialog.py
@@ -6,13 +6,13 @@ from Tkinter import *
 
 class SimpleDialog:
 
-    def __init__(self, master,
+    def __init__(self, main,
                  text='', buttons=[], default=None, cancel=None,
                  title=None, class_=None):
         if class_:
-            self.root = Toplevel(master, class_=class_)
+            self.root = Toplevel(main, class_=class_)
         else:
-            self.root = Toplevel(master)
+            self.root = Toplevel(main)
         if title:
             self.root.title(title)
             self.root.iconname(title)
@@ -32,32 +32,32 @@ class SimpleDialog:
                 b.config(relief=RIDGE, borderwidth=8)
             b.pack(side=LEFT, fill=BOTH, expand=1)
         self.root.protocol('WM_DELETE_WINDOW', self.wm_delete_window)
-        self._set_transient(master)
+        self._set_transient(main)
 
-    def _set_transient(self, master, relx=0.5, rely=0.3):
+    def _set_transient(self, main, relx=0.5, rely=0.3):
         widget = self.root
         widget.withdraw() # Remain invisible while we figure out the geometry
-        widget.transient(master)
+        widget.transient(main)
         widget.update_idletasks() # Actualize geometry information
-        if master.winfo_ismapped():
-            m_width = master.winfo_width()
-            m_height = master.winfo_height()
-            m_x = master.winfo_rootx()
-            m_y = master.winfo_rooty()
+        if main.winfo_ismapped():
+            m_width = main.winfo_width()
+            m_height = main.winfo_height()
+            m_x = main.winfo_rootx()
+            m_y = main.winfo_rooty()
         else:
-            m_width = master.winfo_screenwidth()
-            m_height = master.winfo_screenheight()
+            m_width = main.winfo_screenwidth()
+            m_height = main.winfo_screenheight()
             m_x = m_y = 0
         w_width = widget.winfo_reqwidth()
         w_height = widget.winfo_reqheight()
         x = m_x + (m_width - w_width) * relx
         y = m_y + (m_height - w_height) * rely
-        if x+w_width > master.winfo_screenwidth():
-            x = master.winfo_screenwidth() - w_width
+        if x+w_width > main.winfo_screenwidth():
+            x = main.winfo_screenwidth() - w_width
         elif x < 0:
             x = 0
-        if y+w_height > master.winfo_screenheight():
-            y = master.winfo_screenheight() - w_height
+        if y+w_height > main.winfo_screenheight():
+            y = main.winfo_screenheight() - w_height
         elif y < 0:
             y = 0
         widget.geometry("+%d+%d" % (x, y))

--- a/chroot/usr/lib/python2.7/lib-tk/Tix.py
+++ b/chroot/usr/lib/python2.7/lib-tk/Tix.py
@@ -267,11 +267,11 @@ class Form:
             option = '-' + option
         return self.tk.call('tixForm', 'info', self._w, option)
 
-    def slaves(self):
+    def subordinates(self):
         return map(self._nametowidget,
                    self.tk.splitlist(
                        self.tk.call(
-                       'tixForm', 'slaves', self._w)))
+                       'tixForm', 'subordinates', self._w)))
 
 
 
@@ -290,7 +290,7 @@ class TixWidget(Tkinter.Widget):
 
     Both options are for use by subclasses only.
     """
-    def __init__ (self, master=None, widgetName=None,
+    def __init__ (self, main=None, widgetName=None,
                 static_options=None, cnf={}, kw={}):
         # Merge keywords and dictionary arguments
         if kw:
@@ -314,7 +314,7 @@ class TixWidget(Tkinter.Widget):
                 del cnf[k]
 
         self.widgetName = widgetName
-        Widget._setup(self, master, cnf)
+        Widget._setup(self, main, cnf)
 
         # If widgetName is None, this is a dummy creation call where the
         # corresponding Tk widget has already been created by Tix
@@ -396,10 +396,10 @@ class TixWidget(Tkinter.Widget):
         for name in names:
             self.tk.call(name, 'configure', '-' + option, value)
     # These are missing from Tkinter
-    def image_create(self, imgtype, cnf={}, master=None, **kw):
-        if not master:
-            master = Tkinter._default_root
-            if not master:
+    def image_create(self, imgtype, cnf={}, main=None, **kw):
+        if not main:
+            main = Tkinter._default_root
+            if not main:
                 raise RuntimeError, 'Too early to create image'
         if kw and cnf: cnf = _cnfmerge((cnf, kw))
         elif kw: cnf = kw
@@ -408,7 +408,7 @@ class TixWidget(Tkinter.Widget):
             if hasattr(v, '__call__'):
                 v = self._register(v)
             options = options + ('-'+k, v)
-        return master.tk.call(('image', 'create', imgtype,) + options)
+        return main.tk.call(('image', 'create', imgtype,) + options)
     def image_delete(self, imgname):
         try:
             self.tk.call('image', 'delete', imgname)
@@ -426,26 +426,26 @@ class TixSubWidget(TixWidget):
     by Tix/Tk as part of a mega-widget in Python (which is not informed
     of this)"""
 
-    def __init__(self, master, name,
+    def __init__(self, main, name,
                destroy_physically=1, check_intermediate=1):
         if check_intermediate:
-            path = master._subwidget_name(name)
+            path = main._subwidget_name(name)
             try:
-                path = path[len(master._w)+1:]
+                path = path[len(main._w)+1:]
                 plist = path.split('.')
             except:
                 plist = []
 
         if not check_intermediate:
             # immediate descendant
-            TixWidget.__init__(self, master, None, None, {'name' : name})
+            TixWidget.__init__(self, main, None, None, {'name' : name})
         else:
             # Ensure that the intermediate widgets exist
-            parent = master
+            parent = main
             for i in range(len(plist) - 1):
                 n = '.'.join(plist[:i+1])
                 try:
-                    w = master._nametowidget(n)
+                    w = main._nametowidget(n)
                     parent = w
                 except KeyError:
                     # Create the intermediate widget
@@ -464,10 +464,10 @@ class TixSubWidget(TixWidget):
         # also destroys the parent NoteBook thus leading to an exception
         # in Tkinter when it finally calls Tcl to destroy the NoteBook
         for c in self.children.values(): c.destroy()
-        if self._name in self.master.children:
-            del self.master.children[self._name]
-        if self._name in self.master.subwidget_list:
-            del self.master.subwidget_list[self._name]
+        if self._name in self.main.children:
+            del self.main.children[self._name]
+        if self._name in self.main.subwidget_list:
+            del self.main.subwidget_list[self._name]
         if self.destroy_physically:
             # This is bypassed only for a few widgets
             self.tk.call('destroy', self._w)
@@ -487,11 +487,11 @@ class DisplayStyle:
     (multiple) Display Items"""
 
     def __init__(self, itemtype, cnf={}, **kw):
-        master = _default_root              # global from Tkinter
-        if not master and 'refwindow' in cnf: master=cnf['refwindow']
-        elif not master and 'refwindow' in kw:  master= kw['refwindow']
-        elif not master: raise RuntimeError, "Too early to create display style: no root window"
-        self.tk = master.tk
+        main = _default_root              # global from Tkinter
+        if not main and 'refwindow' in cnf: main=cnf['refwindow']
+        elif not main and 'refwindow' in kw:  main= kw['refwindow']
+        elif not main: raise RuntimeError, "Too early to create display style: no root window"
+        self.tk = main.tk
         self.stylename = self.tk.call('tixDisplayStyle', itemtype,
                             *self._options(cnf,kw) )
 
@@ -537,11 +537,11 @@ class Balloon(TixWidget):
     message         Message"""
 
     # FIXME: It should inherit -superclass tixShell
-    def __init__(self, master=None, cnf={}, **kw):
+    def __init__(self, main=None, cnf={}, **kw):
         # static seem to be -installcolormap -initwait -statusbar -cursor
         static = ['options', 'installcolormap', 'initwait', 'statusbar',
                   'cursor']
-        TixWidget.__init__(self, master, 'tixBalloon', static, cnf, kw)
+        TixWidget.__init__(self, main, 'tixBalloon', static, cnf, kw)
         self.subwidget_list['label'] = _dummyLabel(self, 'label',
                                                    destroy_physically=0)
         self.subwidget_list['message'] = _dummyLabel(self, 'message',
@@ -559,8 +559,8 @@ class ButtonBox(TixWidget):
     """ButtonBox - A container for pushbuttons.
     Subwidgets are the buttons added with the add method.
     """
-    def __init__(self, master=None, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixButtonBox',
+    def __init__(self, main=None, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixButtonBox',
                            ['orientation', 'options'], cnf, kw)
 
     def add(self, name, cnf={}, **kw):
@@ -588,8 +588,8 @@ class ComboBox(TixWidget):
     cross       Button : present if created with the fancy option"""
 
     # FIXME: It should inherit -superclass tixLabelWidget
-    def __init__ (self, master=None, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixComboBox',
+    def __init__ (self, main=None, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixComboBox',
                            ['editable', 'dropdown', 'fancy', 'options'],
                            cnf, kw)
         self.subwidget_list['label'] = _dummyLabel(self, 'label')
@@ -632,8 +632,8 @@ class Control(TixWidget):
     label       Label"""
 
     # FIXME: It should inherit -superclass tixLabelWidget
-    def __init__ (self, master=None, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixControl', ['options'], cnf, kw)
+    def __init__ (self, main=None, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixControl', ['options'], cnf, kw)
         self.subwidget_list['incr'] = _dummyButton(self, 'incr')
         self.subwidget_list['decr'] = _dummyButton(self, 'decr')
         self.subwidget_list['label'] = _dummyLabel(self, 'label')
@@ -663,8 +663,8 @@ class DirList(TixWidget):
     vsb              Scrollbar"""
 
     # FIXME: It should inherit -superclass tixScrolledHList
-    def __init__(self, master, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixDirList', ['options'], cnf, kw)
+    def __init__(self, main, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixDirList', ['options'], cnf, kw)
         self.subwidget_list['hlist'] = _dummyHList(self, 'hlist')
         self.subwidget_list['vsb'] = _dummyScrollbar(self, 'vsb')
         self.subwidget_list['hsb'] = _dummyScrollbar(self, 'hsb')
@@ -685,8 +685,8 @@ class DirTree(TixWidget):
     vsb             Scrollbar"""
 
     # FIXME: It should inherit -superclass tixScrolledHList
-    def __init__(self, master, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixDirTree', ['options'], cnf, kw)
+    def __init__(self, main, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixDirTree', ['options'], cnf, kw)
         self.subwidget_list['hlist'] = _dummyHList(self, 'hlist')
         self.subwidget_list['vsb'] = _dummyScrollbar(self, 'vsb')
         self.subwidget_list['hsb'] = _dummyScrollbar(self, 'hsb')
@@ -708,8 +708,8 @@ class DirSelectBox(TixWidget):
     dirlist         ScrolledListBox
     filelist        ScrolledListBox"""
 
-    def __init__(self, master, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixDirSelectBox', ['options'], cnf, kw)
+    def __init__(self, main, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixDirSelectBox', ['options'], cnf, kw)
         self.subwidget_list['dirlist'] = _dummyDirList(self, 'dirlist')
         self.subwidget_list['dircbx'] = _dummyFileComboBox(self, 'dircbx')
 
@@ -728,8 +728,8 @@ class ExFileSelectBox(TixWidget):
     dirlist       ScrolledListBox
     filelist       ScrolledListBox"""
 
-    def __init__(self, master, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixExFileSelectBox', ['options'], cnf, kw)
+    def __init__(self, main, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixExFileSelectBox', ['options'], cnf, kw)
         self.subwidget_list['cancel'] = _dummyButton(self, 'cancel')
         self.subwidget_list['ok'] = _dummyButton(self, 'ok')
         self.subwidget_list['hidden'] = _dummyCheckbutton(self, 'hidden')
@@ -757,8 +757,8 @@ class DirSelectDialog(TixWidget):
     dirbox       DirSelectDialog"""
 
     # FIXME: It should inherit -superclass tixDialogShell
-    def __init__(self, master, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixDirSelectDialog',
+    def __init__(self, main, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixDirSelectDialog',
                            ['options'], cnf, kw)
         self.subwidget_list['dirbox'] = _dummyDirSelectBox(self, 'dirbox')
         # cancel and ok buttons are missing
@@ -780,8 +780,8 @@ class ExFileSelectDialog(TixWidget):
     fsbox       ExFileSelectBox"""
 
     # FIXME: It should inherit -superclass tixDialogShell
-    def __init__(self, master, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixExFileSelectDialog',
+    def __init__(self, main, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixExFileSelectDialog',
                            ['options'], cnf, kw)
         self.subwidget_list['fsbox'] = _dummyExFileSelectBox(self, 'fsbox')
 
@@ -805,8 +805,8 @@ class FileSelectBox(TixWidget):
     dirlist         ScrolledListBox
     filelist        ScrolledListBox"""
 
-    def __init__(self, master, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixFileSelectBox', ['options'], cnf, kw)
+    def __init__(self, main, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixFileSelectBox', ['options'], cnf, kw)
         self.subwidget_list['dirlist'] = _dummyScrolledListBox(self, 'dirlist')
         self.subwidget_list['filelist'] = _dummyScrolledListBox(self, 'filelist')
         self.subwidget_list['filter'] = _dummyComboBox(self, 'filter')
@@ -828,8 +828,8 @@ class FileSelectDialog(TixWidget):
     fsbox       FileSelectBox"""
 
     # FIXME: It should inherit -superclass tixStdDialogShell
-    def __init__(self, master, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixFileSelectDialog',
+    def __init__(self, main, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixFileSelectDialog',
                            ['options'], cnf, kw)
         self.subwidget_list['btns'] = _dummyStdButtonBox(self, 'btns')
         self.subwidget_list['fsbox'] = _dummyFileSelectBox(self, 'fsbox')
@@ -852,8 +852,8 @@ class FileEntry(TixWidget):
     entry       Entry"""
 
     # FIXME: It should inherit -superclass tixLabelWidget
-    def __init__(self, master, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixFileEntry',
+    def __init__(self, main, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixFileEntry',
                            ['dialogtype', 'options'], cnf, kw)
         self.subwidget_list['button'] = _dummyButton(self, 'button')
         self.subwidget_list['entry'] = _dummyEntry(self, 'entry')
@@ -873,8 +873,8 @@ class HList(TixWidget, XView, YView):
 
     Subwidgets - None"""
 
-    def __init__ (self,master=None,cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixHList',
+    def __init__ (self,main=None,cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixHList',
                            ['columns', 'options'], cnf, kw)
 
     def add(self, entry, cnf={}, **kw):
@@ -1067,8 +1067,8 @@ class InputOnly(TixWidget):
 
     Subwidgets - None"""
 
-    def __init__ (self,master=None,cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixInputOnly', None, cnf, kw)
+    def __init__ (self,main=None,cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixInputOnly', None, cnf, kw)
 
 class LabelEntry(TixWidget):
     """LabelEntry - Entry field with label. Packages an entry widget
@@ -1080,8 +1080,8 @@ class LabelEntry(TixWidget):
     label       Label
     entry       Entry"""
 
-    def __init__ (self,master=None,cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixLabelEntry',
+    def __init__ (self,main=None,cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixLabelEntry',
                            ['labelside','options'], cnf, kw)
         self.subwidget_list['label'] = _dummyLabel(self, 'label')
         self.subwidget_list['entry'] = _dummyEntry(self, 'entry')
@@ -1097,8 +1097,8 @@ class LabelFrame(TixWidget):
     label       Label
     frame       Frame"""
 
-    def __init__ (self,master=None,cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixLabelFrame',
+    def __init__ (self,main=None,cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixLabelFrame',
                            ['labelside','options'], cnf, kw)
         self.subwidget_list['label'] = _dummyLabel(self, 'label')
         self.subwidget_list['frame'] = _dummyFrame(self, 'frame')
@@ -1112,8 +1112,8 @@ class ListNoteBook(TixWidget):
     The user can navigate through these pages by
     choosing the name of the desired page in the hlist subwidget."""
 
-    def __init__(self, master, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixListNoteBook', ['options'], cnf, kw)
+    def __init__(self, main, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixListNoteBook', ['options'], cnf, kw)
         # Is this necessary? It's not an exposed subwidget in Tix.
         self.subwidget_list['pane'] = _dummyPanedWindow(self, 'pane',
                                                         destroy_physically=0)
@@ -1144,8 +1144,8 @@ class Meter(TixWidget):
     job which may take a long time to execute.
     """
 
-    def __init__(self, master=None, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixMeter',
+    def __init__(self, main=None, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixMeter',
                            ['options'], cnf, kw)
 
 class NoteBook(TixWidget):
@@ -1156,8 +1156,8 @@ class NoteBook(TixWidget):
     nbframe       NoteBookFrame
     <pages>       page widgets added dynamically with the add method"""
 
-    def __init__ (self,master=None,cnf={}, **kw):
-        TixWidget.__init__(self,master,'tixNoteBook', ['options'], cnf, kw)
+    def __init__ (self,main=None,cnf={}, **kw):
+        TixWidget.__init__(self,main,'tixNoteBook', ['options'], cnf, kw)
         self.subwidget_list['nbframe'] = TixSubWidget(self, 'nbframe',
                                                       destroy_physically=0)
 
@@ -1200,8 +1200,8 @@ class OptionMenu(TixWidget):
     menubutton      Menubutton
     menu            Menu"""
 
-    def __init__(self, master, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixOptionMenu',
+    def __init__(self, main, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixOptionMenu',
                 ['labelside', 'options'], cnf, kw)
         self.subwidget_list['menubutton'] = _dummyMenubutton(self, 'menubutton')
         self.subwidget_list['menu'] = _dummyMenu(self, 'menu')
@@ -1232,8 +1232,8 @@ class PanedWindow(TixWidget):
     ----------       -----
     <panes>       g/p widgets added dynamically with the add method."""
 
-    def __init__(self, master, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixPanedWindow', ['orientation', 'options'], cnf, kw)
+    def __init__(self, main, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixPanedWindow', ['orientation', 'options'], cnf, kw)
 
     # add delete forget panecget paneconfigure panes setsize
     def add(self, name, cnf={}, **kw):
@@ -1276,8 +1276,8 @@ class PopupMenu(TixWidget):
     menu       Menu"""
 
     # FIXME: It should inherit -superclass tixShell
-    def __init__(self, master, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixPopupMenu', ['options'], cnf, kw)
+    def __init__(self, main, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixPopupMenu', ['options'], cnf, kw)
         self.subwidget_list['menubutton'] = _dummyMenubutton(self, 'menubutton')
         self.subwidget_list['menu'] = _dummyMenu(self, 'menu')
 
@@ -1292,14 +1292,14 @@ class PopupMenu(TixWidget):
 
 class ResizeHandle(TixWidget):
     """Internal widget to draw resize handles on Scrolled widgets."""
-    def __init__(self, master, cnf={}, **kw):
+    def __init__(self, main, cnf={}, **kw):
         # There seems to be a Tix bug rejecting the configure method
         # Let's try making the flags -static
         flags = ['options', 'command', 'cursorfg', 'cursorbg',
                  'handlesize', 'hintcolor', 'hintwidth',
                  'x', 'y']
         # In fact, x y height width are configurable
-        TixWidget.__init__(self, master, 'tixResizeHandle',
+        TixWidget.__init__(self, main, 'tixResizeHandle',
                            flags, cnf, kw)
 
     def attach_widget(self, widget):
@@ -1318,8 +1318,8 @@ class ScrolledHList(TixWidget):
     """ScrolledHList - HList with automatic scrollbars."""
 
     # FIXME: It should inherit -superclass tixScrolledWidget
-    def __init__(self, master, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixScrolledHList', ['options'],
+    def __init__(self, main, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixScrolledHList', ['options'],
                            cnf, kw)
         self.subwidget_list['hlist'] = _dummyHList(self, 'hlist')
         self.subwidget_list['vsb'] = _dummyScrollbar(self, 'vsb')
@@ -1329,8 +1329,8 @@ class ScrolledListBox(TixWidget):
     """ScrolledListBox - Listbox with automatic scrollbars."""
 
     # FIXME: It should inherit -superclass tixScrolledWidget
-    def __init__(self, master, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixScrolledListBox', ['options'], cnf, kw)
+    def __init__(self, main, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixScrolledListBox', ['options'], cnf, kw)
         self.subwidget_list['listbox'] = _dummyListbox(self, 'listbox')
         self.subwidget_list['vsb'] = _dummyScrollbar(self, 'vsb')
         self.subwidget_list['hsb'] = _dummyScrollbar(self, 'hsb')
@@ -1339,8 +1339,8 @@ class ScrolledText(TixWidget):
     """ScrolledText - Text with automatic scrollbars."""
 
     # FIXME: It should inherit -superclass tixScrolledWidget
-    def __init__(self, master, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixScrolledText', ['options'], cnf, kw)
+    def __init__(self, main, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixScrolledText', ['options'], cnf, kw)
         self.subwidget_list['text'] = _dummyText(self, 'text')
         self.subwidget_list['vsb'] = _dummyScrollbar(self, 'vsb')
         self.subwidget_list['hsb'] = _dummyScrollbar(self, 'hsb')
@@ -1349,8 +1349,8 @@ class ScrolledTList(TixWidget):
     """ScrolledTList - TList with automatic scrollbars."""
 
     # FIXME: It should inherit -superclass tixScrolledWidget
-    def __init__(self, master, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixScrolledTList', ['options'],
+    def __init__(self, main, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixScrolledTList', ['options'],
                            cnf, kw)
         self.subwidget_list['tlist'] = _dummyTList(self, 'tlist')
         self.subwidget_list['vsb'] = _dummyScrollbar(self, 'vsb')
@@ -1360,8 +1360,8 @@ class ScrolledWindow(TixWidget):
     """ScrolledWindow - Window with automatic scrollbars."""
 
     # FIXME: It should inherit -superclass tixScrolledWidget
-    def __init__(self, master, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixScrolledWindow', ['options'], cnf, kw)
+    def __init__(self, main, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixScrolledWindow', ['options'], cnf, kw)
         self.subwidget_list['window'] = _dummyFrame(self, 'window')
         self.subwidget_list['vsb'] = _dummyScrollbar(self, 'vsb')
         self.subwidget_list['hsb'] = _dummyScrollbar(self, 'hsb')
@@ -1373,8 +1373,8 @@ class Select(TixWidget):
     Subwidgets are buttons added dynamically using the add method."""
 
     # FIXME: It should inherit -superclass tixLabelWidget
-    def __init__(self, master, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixSelect',
+    def __init__(self, main, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixSelect',
                            ['allowzero', 'radio', 'orientation', 'labelside',
                             'options'],
                            cnf, kw)
@@ -1393,8 +1393,8 @@ class Shell(TixWidget):
 
     Subwidgets - None"""
 
-    def __init__ (self,master=None,cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixShell', ['options', 'title'], cnf, kw)
+    def __init__ (self,main=None,cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixShell', ['options', 'title'], cnf, kw)
 
 class DialogShell(TixWidget):
     """Toplevel window, with popup popdown and center methods.
@@ -1405,8 +1405,8 @@ class DialogShell(TixWidget):
     Subwidgets - None"""
 
     # FIXME: It should inherit from  Shell
-    def __init__ (self,master=None,cnf={}, **kw):
-        TixWidget.__init__(self, master,
+    def __init__ (self,main=None,cnf={}, **kw):
+        TixWidget.__init__(self, main,
                            'tixDialogShell',
                            ['options', 'title', 'mapped',
                             'minheight', 'minwidth',
@@ -1424,8 +1424,8 @@ class DialogShell(TixWidget):
 class StdButtonBox(TixWidget):
     """StdButtonBox - Standard Button Box (OK, Apply, Cancel and Help) """
 
-    def __init__(self, master=None, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixStdButtonBox',
+    def __init__(self, main=None, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixStdButtonBox',
                            ['orientation', 'options'], cnf, kw)
         self.subwidget_list['ok'] = _dummyButton(self, 'ok')
         self.subwidget_list['apply'] = _dummyButton(self, 'apply')
@@ -1446,8 +1446,8 @@ class TList(TixWidget, XView, YView):
 
     Subwidgets - None"""
 
-    def __init__ (self,master=None,cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixTList', ['options'], cnf, kw)
+    def __init__ (self,main=None,cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixTList', ['options'], cnf, kw)
 
     def active_set(self, index):
         self.tk.call(self._w, 'active', 'set', index)
@@ -1525,8 +1525,8 @@ class Tree(TixWidget):
     the view of the tree by opening or closing parts of the tree."""
 
     # FIXME: It should inherit -superclass tixScrolledWidget
-    def __init__(self, master=None, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixTree',
+    def __init__(self, main=None, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixTree',
                            ['options'], cnf, kw)
         self.subwidget_list['hlist'] = _dummyHList(self, 'hlist')
         self.subwidget_list['vsb'] = _dummyScrollbar(self, 'vsb')
@@ -1572,8 +1572,8 @@ class CheckList(TixWidget):
     capable of handling many more items than checkbuttons or radiobuttons.
     """
     # FIXME: It should inherit -superclass tixTree
-    def __init__(self, master=None, cnf={}, **kw):
-        TixWidget.__init__(self, master, 'tixCheckList',
+    def __init__(self, main=None, cnf={}, **kw):
+        TixWidget.__init__(self, main, 'tixCheckList',
                            ['options', 'radio'], cnf, kw)
         self.subwidget_list['hlist'] = _dummyHList(self, 'hlist')
         self.subwidget_list['vsb'] = _dummyScrollbar(self, 'vsb')
@@ -1621,70 +1621,70 @@ class CheckList(TixWidget):
 ###########################################################################
 
 class _dummyButton(Button, TixSubWidget):
-    def __init__(self, master, name, destroy_physically=1):
-        TixSubWidget.__init__(self, master, name, destroy_physically)
+    def __init__(self, main, name, destroy_physically=1):
+        TixSubWidget.__init__(self, main, name, destroy_physically)
 
 class _dummyCheckbutton(Checkbutton, TixSubWidget):
-    def __init__(self, master, name, destroy_physically=1):
-        TixSubWidget.__init__(self, master, name, destroy_physically)
+    def __init__(self, main, name, destroy_physically=1):
+        TixSubWidget.__init__(self, main, name, destroy_physically)
 
 class _dummyEntry(Entry, TixSubWidget):
-    def __init__(self, master, name, destroy_physically=1):
-        TixSubWidget.__init__(self, master, name, destroy_physically)
+    def __init__(self, main, name, destroy_physically=1):
+        TixSubWidget.__init__(self, main, name, destroy_physically)
 
 class _dummyFrame(Frame, TixSubWidget):
-    def __init__(self, master, name, destroy_physically=1):
-        TixSubWidget.__init__(self, master, name, destroy_physically)
+    def __init__(self, main, name, destroy_physically=1):
+        TixSubWidget.__init__(self, main, name, destroy_physically)
 
 class _dummyLabel(Label, TixSubWidget):
-    def __init__(self, master, name, destroy_physically=1):
-        TixSubWidget.__init__(self, master, name, destroy_physically)
+    def __init__(self, main, name, destroy_physically=1):
+        TixSubWidget.__init__(self, main, name, destroy_physically)
 
 class _dummyListbox(Listbox, TixSubWidget):
-    def __init__(self, master, name, destroy_physically=1):
-        TixSubWidget.__init__(self, master, name, destroy_physically)
+    def __init__(self, main, name, destroy_physically=1):
+        TixSubWidget.__init__(self, main, name, destroy_physically)
 
 class _dummyMenu(Menu, TixSubWidget):
-    def __init__(self, master, name, destroy_physically=1):
-        TixSubWidget.__init__(self, master, name, destroy_physically)
+    def __init__(self, main, name, destroy_physically=1):
+        TixSubWidget.__init__(self, main, name, destroy_physically)
 
 class _dummyMenubutton(Menubutton, TixSubWidget):
-    def __init__(self, master, name, destroy_physically=1):
-        TixSubWidget.__init__(self, master, name, destroy_physically)
+    def __init__(self, main, name, destroy_physically=1):
+        TixSubWidget.__init__(self, main, name, destroy_physically)
 
 class _dummyScrollbar(Scrollbar, TixSubWidget):
-    def __init__(self, master, name, destroy_physically=1):
-        TixSubWidget.__init__(self, master, name, destroy_physically)
+    def __init__(self, main, name, destroy_physically=1):
+        TixSubWidget.__init__(self, main, name, destroy_physically)
 
 class _dummyText(Text, TixSubWidget):
-    def __init__(self, master, name, destroy_physically=1):
-        TixSubWidget.__init__(self, master, name, destroy_physically)
+    def __init__(self, main, name, destroy_physically=1):
+        TixSubWidget.__init__(self, main, name, destroy_physically)
 
 class _dummyScrolledListBox(ScrolledListBox, TixSubWidget):
-    def __init__(self, master, name, destroy_physically=1):
-        TixSubWidget.__init__(self, master, name, destroy_physically)
+    def __init__(self, main, name, destroy_physically=1):
+        TixSubWidget.__init__(self, main, name, destroy_physically)
         self.subwidget_list['listbox'] = _dummyListbox(self, 'listbox')
         self.subwidget_list['vsb'] = _dummyScrollbar(self, 'vsb')
         self.subwidget_list['hsb'] = _dummyScrollbar(self, 'hsb')
 
 class _dummyHList(HList, TixSubWidget):
-    def __init__(self, master, name, destroy_physically=1):
-        TixSubWidget.__init__(self, master, name, destroy_physically)
+    def __init__(self, main, name, destroy_physically=1):
+        TixSubWidget.__init__(self, main, name, destroy_physically)
 
 class _dummyScrolledHList(ScrolledHList, TixSubWidget):
-    def __init__(self, master, name, destroy_physically=1):
-        TixSubWidget.__init__(self, master, name, destroy_physically)
+    def __init__(self, main, name, destroy_physically=1):
+        TixSubWidget.__init__(self, main, name, destroy_physically)
         self.subwidget_list['hlist'] = _dummyHList(self, 'hlist')
         self.subwidget_list['vsb'] = _dummyScrollbar(self, 'vsb')
         self.subwidget_list['hsb'] = _dummyScrollbar(self, 'hsb')
 
 class _dummyTList(TList, TixSubWidget):
-    def __init__(self, master, name, destroy_physically=1):
-        TixSubWidget.__init__(self, master, name, destroy_physically)
+    def __init__(self, main, name, destroy_physically=1):
+        TixSubWidget.__init__(self, main, name, destroy_physically)
 
 class _dummyComboBox(ComboBox, TixSubWidget):
-    def __init__(self, master, name, destroy_physically=1):
-        TixSubWidget.__init__(self, master, name, ['fancy',destroy_physically])
+    def __init__(self, main, name, destroy_physically=1):
+        TixSubWidget.__init__(self, main, name, ['fancy',destroy_physically])
         self.subwidget_list['label'] = _dummyLabel(self, 'label')
         self.subwidget_list['entry'] = _dummyEntry(self, 'entry')
         self.subwidget_list['arrow'] = _dummyButton(self, 'arrow')
@@ -1700,21 +1700,21 @@ class _dummyComboBox(ComboBox, TixSubWidget):
             pass
 
 class _dummyDirList(DirList, TixSubWidget):
-    def __init__(self, master, name, destroy_physically=1):
-        TixSubWidget.__init__(self, master, name, destroy_physically)
+    def __init__(self, main, name, destroy_physically=1):
+        TixSubWidget.__init__(self, main, name, destroy_physically)
         self.subwidget_list['hlist'] = _dummyHList(self, 'hlist')
         self.subwidget_list['vsb'] = _dummyScrollbar(self, 'vsb')
         self.subwidget_list['hsb'] = _dummyScrollbar(self, 'hsb')
 
 class _dummyDirSelectBox(DirSelectBox, TixSubWidget):
-    def __init__(self, master, name, destroy_physically=1):
-        TixSubWidget.__init__(self, master, name, destroy_physically)
+    def __init__(self, main, name, destroy_physically=1):
+        TixSubWidget.__init__(self, main, name, destroy_physically)
         self.subwidget_list['dirlist'] = _dummyDirList(self, 'dirlist')
         self.subwidget_list['dircbx'] = _dummyFileComboBox(self, 'dircbx')
 
 class _dummyExFileSelectBox(ExFileSelectBox, TixSubWidget):
-    def __init__(self, master, name, destroy_physically=1):
-        TixSubWidget.__init__(self, master, name, destroy_physically)
+    def __init__(self, main, name, destroy_physically=1):
+        TixSubWidget.__init__(self, main, name, destroy_physically)
         self.subwidget_list['cancel'] = _dummyButton(self, 'cancel')
         self.subwidget_list['ok'] = _dummyButton(self, 'ok')
         self.subwidget_list['hidden'] = _dummyCheckbutton(self, 'hidden')
@@ -1725,33 +1725,33 @@ class _dummyExFileSelectBox(ExFileSelectBox, TixSubWidget):
         self.subwidget_list['filelist'] = _dummyScrolledListBox(self, 'filelist')
 
 class _dummyFileSelectBox(FileSelectBox, TixSubWidget):
-    def __init__(self, master, name, destroy_physically=1):
-        TixSubWidget.__init__(self, master, name, destroy_physically)
+    def __init__(self, main, name, destroy_physically=1):
+        TixSubWidget.__init__(self, main, name, destroy_physically)
         self.subwidget_list['dirlist'] = _dummyScrolledListBox(self, 'dirlist')
         self.subwidget_list['filelist'] = _dummyScrolledListBox(self, 'filelist')
         self.subwidget_list['filter'] = _dummyComboBox(self, 'filter')
         self.subwidget_list['selection'] = _dummyComboBox(self, 'selection')
 
 class _dummyFileComboBox(ComboBox, TixSubWidget):
-    def __init__(self, master, name, destroy_physically=1):
-        TixSubWidget.__init__(self, master, name, destroy_physically)
+    def __init__(self, main, name, destroy_physically=1):
+        TixSubWidget.__init__(self, main, name, destroy_physically)
         self.subwidget_list['dircbx'] = _dummyComboBox(self, 'dircbx')
 
 class _dummyStdButtonBox(StdButtonBox, TixSubWidget):
-    def __init__(self, master, name, destroy_physically=1):
-        TixSubWidget.__init__(self, master, name, destroy_physically)
+    def __init__(self, main, name, destroy_physically=1):
+        TixSubWidget.__init__(self, main, name, destroy_physically)
         self.subwidget_list['ok'] = _dummyButton(self, 'ok')
         self.subwidget_list['apply'] = _dummyButton(self, 'apply')
         self.subwidget_list['cancel'] = _dummyButton(self, 'cancel')
         self.subwidget_list['help'] = _dummyButton(self, 'help')
 
 class _dummyNoteBookFrame(NoteBookFrame, TixSubWidget):
-    def __init__(self, master, name, destroy_physically=0):
-        TixSubWidget.__init__(self, master, name, destroy_physically)
+    def __init__(self, main, name, destroy_physically=0):
+        TixSubWidget.__init__(self, main, name, destroy_physically)
 
 class _dummyPanedWindow(PanedWindow, TixSubWidget):
-    def __init__(self, master, name, destroy_physically=1):
-        TixSubWidget.__init__(self, master, name, destroy_physically)
+    def __init__(self, main, name, destroy_physically=1):
+        TixSubWidget.__init__(self, main, name, destroy_physically)
 
 ########################
 ### Utility Routines ###
@@ -1806,10 +1806,10 @@ class Grid(TixWidget, XView, YView):
     # editdonecmd, editnotifycmd, floatingcols, floatingrows, formatcmd,
     # highlightbackground, highlightcolor, leftmargin, itemtype, selectmode,
     # selectunit, topmargin,
-    def __init__(self, master=None, cnf={}, **kw):
+    def __init__(self, main=None, cnf={}, **kw):
         static= []
         self.cnf= cnf
-        TixWidget.__init__(self, master, 'tixGrid', static, cnf, kw)
+        TixWidget.__init__(self, main, 'tixGrid', static, cnf, kw)
 
     # valid options as of Tk 8.4
     # anchor, bdtype, cget, configure, delete, dragsite, dropsite, entrycget,
@@ -1959,7 +1959,7 @@ class ScrolledGrid(Grid):
     '''Scrolled Grid widgets'''
 
     # FIXME: It should inherit -superclass tixScrolledWidget
-    def __init__(self, master=None, cnf={}, **kw):
+    def __init__(self, main=None, cnf={}, **kw):
         static= []
         self.cnf= cnf
-        TixWidget.__init__(self, master, 'tixScrolledGrid', static, cnf, kw)
+        TixWidget.__init__(self, main, 'tixScrolledGrid', static, cnf, kw)

--- a/chroot/usr/lib/python2.7/lib-tk/Tkdnd.py
+++ b/chroot/usr/lib/python2.7/lib-tk/Tkdnd.py
@@ -162,7 +162,7 @@ class DndHandler:
                 new_target = attr(source, event)
                 if new_target:
                     break
-            target_widget = target_widget.master
+            target_widget = target_widget.main
         old_target = self.target
         if old_target is new_target:
             if old_target:

--- a/chroot/usr/lib/python2.7/lib-tk/Tkinter.py
+++ b/chroot/usr/lib/python2.7/lib-tk/Tkinter.py
@@ -168,10 +168,10 @@ class Variable:
     Subclasses StringVar, IntVar, DoubleVar, BooleanVar are specializations
     that constrain the type of the value returned from get()."""
     _default = ""
-    def __init__(self, master=None, value=None, name=None):
+    def __init__(self, main=None, value=None, name=None):
         """Construct a variable
 
-        MASTER can be given as master widget.
+        MASTER can be given as main widget.
         VALUE is an optional value (defaults to "")
         NAME is an optional Tcl name (defaults to PY_VARnum).
 
@@ -179,10 +179,10 @@ class Variable:
         then the existing value is retained.
         """
         global _varnum
-        if not master:
-            master = _default_root
-        self._master = master
-        self._tk = master.tk
+        if not main:
+            main = _default_root
+        self._main = main
+        self._tk = main.tk
         if name:
             self._name = name
         else:
@@ -213,7 +213,7 @@ class Variable:
 
         Return the name of the callback.
         """
-        cbname = self._master._register(callback)
+        cbname = self._main._register(callback)
         self._tk.call("trace", "variable", self._name, mode, cbname)
         return cbname
     trace = trace_variable
@@ -224,7 +224,7 @@ class Variable:
         CBNAME is the name of the callback returned from trace_variable or trace.
         """
         self._tk.call("trace", "vdelete", self._name, mode, cbname)
-        self._master.deletecommand(cbname)
+        self._main.deletecommand(cbname)
     def trace_vinfo(self):
         """Return all trace callback information."""
         return map(self._tk.split, self._tk.splitlist(
@@ -232,8 +232,8 @@ class Variable:
     def __eq__(self, other):
         """Comparison for equality (==).
 
-        Note: if the Variable's master matters to behavior
-        also compare self._master == other._master
+        Note: if the Variable's main matters to behavior
+        also compare self._main == other._main
         """
         return self.__class__.__name__ == other.__class__.__name__ \
             and self._name == other._name
@@ -241,17 +241,17 @@ class Variable:
 class StringVar(Variable):
     """Value holder for strings variables."""
     _default = ""
-    def __init__(self, master=None, value=None, name=None):
+    def __init__(self, main=None, value=None, name=None):
         """Construct a string variable.
 
-        MASTER can be given as master widget.
+        MASTER can be given as main widget.
         VALUE is an optional value (defaults to "")
         NAME is an optional Tcl name (defaults to PY_VARnum).
 
         If NAME matches an existing variable and VALUE is omitted
         then the existing value is retained.
         """
-        Variable.__init__(self, master, value, name)
+        Variable.__init__(self, main, value, name)
 
     def get(self):
         """Return value of variable as string."""
@@ -263,17 +263,17 @@ class StringVar(Variable):
 class IntVar(Variable):
     """Value holder for integer variables."""
     _default = 0
-    def __init__(self, master=None, value=None, name=None):
+    def __init__(self, main=None, value=None, name=None):
         """Construct an integer variable.
 
-        MASTER can be given as master widget.
+        MASTER can be given as main widget.
         VALUE is an optional value (defaults to 0)
         NAME is an optional Tcl name (defaults to PY_VARnum).
 
         If NAME matches an existing variable and VALUE is omitted
         then the existing value is retained.
         """
-        Variable.__init__(self, master, value, name)
+        Variable.__init__(self, main, value, name)
 
     def set(self, value):
         """Set the variable to value, converting booleans to integers."""
@@ -288,17 +288,17 @@ class IntVar(Variable):
 class DoubleVar(Variable):
     """Value holder for float variables."""
     _default = 0.0
-    def __init__(self, master=None, value=None, name=None):
+    def __init__(self, main=None, value=None, name=None):
         """Construct a float variable.
 
-        MASTER can be given as master widget.
+        MASTER can be given as main widget.
         VALUE is an optional value (defaults to 0.0)
         NAME is an optional Tcl name (defaults to PY_VARnum).
 
         If NAME matches an existing variable and VALUE is omitted
         then the existing value is retained.
         """
-        Variable.__init__(self, master, value, name)
+        Variable.__init__(self, main, value, name)
 
     def get(self):
         """Return the value of the variable as a float."""
@@ -307,17 +307,17 @@ class DoubleVar(Variable):
 class BooleanVar(Variable):
     """Value holder for boolean variables."""
     _default = False
-    def __init__(self, master=None, value=None, name=None):
+    def __init__(self, main=None, value=None, name=None):
         """Construct a boolean variable.
 
-        MASTER can be given as master widget.
+        MASTER can be given as main widget.
         VALUE is an optional value (defaults to False)
         NAME is an optional Tcl name (defaults to PY_VARnum).
 
         If NAME matches an existing variable and VALUE is omitted
         then the existing value is retained.
         """
-        Variable.__init__(self, master, value, name)
+        Variable.__init__(self, main, value, name)
 
     def get(self):
         """Return the value of the variable as a bool."""
@@ -1108,7 +1108,7 @@ class Misc:
     def _root(self):
         """Internal function."""
         w = self
-        while w.master: w = w.master
+        while w.main: w = w.main
         return w
     _subst_format = ('%#', '%b', '%f', '%h', '%k',
              '%s', '%t', '%w', '%x', '%y',
@@ -1219,13 +1219,13 @@ class Misc:
     def __str__(self):
         """Return the window path name of this widget."""
         return self._w
-    # Pack methods that apply to the master
+    # Pack methods that apply to the main
     _noarg_ = ['_noarg_']
     def pack_propagate(self, flag=_noarg_):
         """Set or get the status for propagation of geometry information.
 
         A boolean argument specifies whether the geometry information
-        of the slaves will determine the size of this widget. If no argument
+        of the subordinates will determine the size of this widget. If no argument
         is given the current setting will be returned.
         """
         if flag is Misc._noarg_:
@@ -1234,22 +1234,22 @@ class Misc:
         else:
             self.tk.call('pack', 'propagate', self._w, flag)
     propagate = pack_propagate
-    def pack_slaves(self):
-        """Return a list of all slaves of this widget
+    def pack_subordinates(self):
+        """Return a list of all subordinates of this widget
         in its packing order."""
         return map(self._nametowidget,
                self.tk.splitlist(
-                   self.tk.call('pack', 'slaves', self._w)))
-    slaves = pack_slaves
-    # Place method that applies to the master
-    def place_slaves(self):
-        """Return a list of all slaves of this widget
+                   self.tk.call('pack', 'subordinates', self._w)))
+    subordinates = pack_subordinates
+    # Place method that applies to the main
+    def place_subordinates(self):
+        """Return a list of all subordinates of this widget
         in its packing order."""
         return map(self._nametowidget,
                self.tk.splitlist(
                    self.tk.call(
-                       'place', 'slaves', self._w)))
-    # Grid methods that apply to the master
+                       'place', 'subordinates', self._w)))
+    # Grid methods that apply to the main
     def grid_bbox(self, column=None, row=None, col2=None, row2=None):
         """Return a tuple of integer coordinates for the bounding
         box of this widget controlled by the geometry manager grid.
@@ -1260,7 +1260,7 @@ class Misc:
         starts at that cell.
 
         The returned integers specify the offset of the upper left
-        corner in the master widget and the width and height.
+        corner in the main widget and the width and height.
         """
         args = ('grid', 'bbox', self._w)
         if column is not None and row is not None:
@@ -1314,7 +1314,7 @@ class Misc:
     columnconfigure = grid_columnconfigure
     def grid_location(self, x, y):
         """Return a tuple of column and row which identify the cell
-        at which the pixel at position X and Y inside the master
+        at which the pixel at position X and Y inside the main
         widget is located."""
         return self._getints(
             self.tk.call(
@@ -1323,7 +1323,7 @@ class Misc:
         """Set or get the status for propagation of geometry information.
 
         A boolean argument specifies whether the geometry information
-        of the slaves will determine the size of this widget. If no argument
+        of the subordinates will determine the size of this widget. If no argument
         is given, the current setting will be returned.
         """
         if flag is Misc._noarg_:
@@ -1344,8 +1344,8 @@ class Misc:
         return self._getints(
             self.tk.call('grid', 'size', self._w)) or None
     size = grid_size
-    def grid_slaves(self, row=None, column=None):
-        """Return a list of all slaves of this widget
+    def grid_subordinates(self, row=None, column=None):
+        """Return a list of all subordinates of this widget
         in its packing order."""
         args = ()
         if row is not None:
@@ -1354,7 +1354,7 @@ class Misc:
             args = args + ('-column', column)
         return map(self._nametowidget,
                self.tk.splitlist(self.tk.call(
-                   ('grid', 'slaves', self._w) + args)))
+                   ('grid', 'subordinates', self._w) + args)))
 
     # Support for the "event" command, new in Tk 4.2.
     # By Case Roole.
@@ -1649,10 +1649,10 @@ class Wm:
         """Set the title of this widget."""
         return self.tk.call('wm', 'title', self._w, string)
     title = wm_title
-    def wm_transient(self, master=None):
+    def wm_transient(self, main=None):
         """Instruct the window manager that this widget is transient
         with regard to widget MASTER."""
-        return self.tk.call('wm', 'transient', self._w, master)
+        return self.tk.call('wm', 'transient', self._w, main)
     transient = wm_transient
     def wm_withdraw(self):
         """Withdraw this widget from the screen such that it is unmapped
@@ -1672,7 +1672,7 @@ class Tk(Misc, Wm):
         readprofile).
         It is constructed from sys.argv[0] without extensions if None is given. CLASSNAME
         is the name of the widget class."""
-        self.master = None
+        self.main = None
         self.children = {}
         self._tkloaded = 0
         # to avoid recursions in the getattr code in case of failure, we
@@ -1775,7 +1775,7 @@ class Tk(Misc, Wm):
 # afraid that there is too much code out there that may be using the
 # Pack, Place or Grid class, so I leave them intact -- but only as
 # backwards compatibility features.  Also note that those methods that
-# take a master as argument (e.g. pack_propagate) have been moved to
+# take a main as argument (e.g. pack_propagate) have been moved to
 # the Misc class (which now incorporates all methods common between
 # toplevel and interior widgets).  Again, for compatibility, these are
 # copied into the Pack, Place or Grid class.
@@ -1796,8 +1796,8 @@ class Pack:
         before=widget - pack it before you will pack widget
         expand=bool - expand widget if parent size grows
         fill=NONE or X or Y or BOTH - fill widget if widget grows
-        in=master - use master to contain this widget
-        in_=master - see 'in' option description
+        in=main - use main to contain this widget
+        in_=main - see 'in' option description
         ipadx=amount - add internal padding in x direction
         ipady=amount - add internal padding in y direction
         padx=amount - add padding in x direction
@@ -1827,7 +1827,7 @@ class Pack:
         return dict
     info = pack_info
     propagate = pack_propagate = Misc.pack_propagate
-    slaves = pack_slaves = Misc.pack_slaves
+    subordinates = pack_subordinates = Misc.pack_subordinates
 
 class Place:
     """Geometry manager Place.
@@ -1835,25 +1835,25 @@ class Place:
     Base class to use the methods place_* in every widget."""
     def place_configure(self, cnf={}, **kw):
         """Place a widget in the parent widget. Use as options:
-        in=master - master relative to which the widget is placed
-        in_=master - see 'in' option description
-        x=amount - locate anchor of this widget at position x of master
-        y=amount - locate anchor of this widget at position y of master
+        in=main - main relative to which the widget is placed
+        in_=main - see 'in' option description
+        x=amount - locate anchor of this widget at position x of main
+        y=amount - locate anchor of this widget at position y of main
         relx=amount - locate anchor of this widget between 0.0 and 1.0
-                      relative to width of master (1.0 is right edge)
+                      relative to width of main (1.0 is right edge)
         rely=amount - locate anchor of this widget between 0.0 and 1.0
-                      relative to height of master (1.0 is bottom edge)
+                      relative to height of main (1.0 is bottom edge)
         anchor=NSEW (or subset) - position anchor according to given direction
         width=amount - width of this widget in pixel
         height=amount - height of this widget in pixel
         relwidth=amount - width of this widget between 0.0 and 1.0
-                          relative to width of master (1.0 is the same width
-                          as the master)
+                          relative to width of main (1.0 is the same width
+                          as the main)
         relheight=amount - height of this widget between 0.0 and 1.0
-                           relative to height of master (1.0 is the same
-                           height as the master)
+                           relative to height of main (1.0 is the same
+                           height as the main)
         bordermode="inside" or "outside" - whether to take border width of
-                                           master widget into account
+                                           main widget into account
         """
         self.tk.call(
               ('place', 'configure', self._w)
@@ -1877,7 +1877,7 @@ class Place:
             dict[key] = value
         return dict
     info = place_info
-    slaves = place_slaves = Misc.place_slaves
+    subordinates = place_subordinates = Misc.place_subordinates
 
 class Grid:
     """Geometry manager Grid.
@@ -1888,8 +1888,8 @@ class Grid:
         """Position a widget in the parent widget in a grid. Use as options:
         column=number - use cell identified with given column (starting with 0)
         columnspan=number - this widget will span several columns
-        in=master - use master to contain this widget
-        in_=master - see 'in' option description
+        in=main - use main to contain this widget
+        in_=main - see 'in' option description
         ipadx=amount - add internal padding in x direction
         ipady=amount - add internal padding in y direction
         padx=amount - add padding in x direction
@@ -1930,20 +1930,20 @@ class Grid:
     propagate = grid_propagate = Misc.grid_propagate
     rowconfigure = grid_rowconfigure = Misc.grid_rowconfigure
     size = grid_size = Misc.grid_size
-    slaves = grid_slaves = Misc.grid_slaves
+    subordinates = grid_subordinates = Misc.grid_subordinates
 
 class BaseWidget(Misc):
     """Internal class."""
-    def _setup(self, master, cnf):
+    def _setup(self, main, cnf):
         """Internal function. Sets up information about children."""
         if _support_default_root:
             global _default_root
-            if not master:
+            if not main:
                 if not _default_root:
                     _default_root = Tk()
-                master = _default_root
-        self.master = master
-        self.tk = master.tk
+                main = _default_root
+        self.main = main
+        self.tk = main.tk
         name = None
         if 'name' in cnf:
             name = cnf['name']
@@ -1951,21 +1951,21 @@ class BaseWidget(Misc):
         if not name:
             name = repr(id(self))
         self._name = name
-        if master._w=='.':
+        if main._w=='.':
             self._w = '.' + name
         else:
-            self._w = master._w + '.' + name
+            self._w = main._w + '.' + name
         self.children = {}
-        if self._name in self.master.children:
-            self.master.children[self._name].destroy()
-        self.master.children[self._name] = self
-    def __init__(self, master, widgetName, cnf={}, kw={}, extra=()):
+        if self._name in self.main.children:
+            self.main.children[self._name].destroy()
+        self.main.children[self._name] = self
+    def __init__(self, main, widgetName, cnf={}, kw={}, extra=()):
         """Construct a widget with the parent widget MASTER, a name WIDGETNAME
         and appropriate options."""
         if kw:
             cnf = _cnfmerge((cnf, kw))
         self.widgetName = widgetName
-        BaseWidget._setup(self, master, cnf)
+        BaseWidget._setup(self, main, cnf)
         if self._tclCommands is None:
             self._tclCommands = []
         classes = []
@@ -1981,8 +1981,8 @@ class BaseWidget(Misc):
         """Destroy this and all descendants widgets."""
         for c in self.children.values(): c.destroy()
         self.tk.call('destroy', self._w)
-        if self._name in self.master.children:
-            del self.master.children[self._name]
+        if self._name in self.main.children:
+            del self.main.children[self._name]
         Misc.destroy(self)
     def _do(self, name, args=()):
         # XXX Obsolete -- better use self.tk.call directly!
@@ -1997,7 +1997,7 @@ class Widget(BaseWidget, Pack, Place, Grid):
 
 class Toplevel(BaseWidget, Wm):
     """Toplevel widget, e.g. for dialogs."""
-    def __init__(self, master=None, cnf={}, **kw):
+    def __init__(self, main=None, cnf={}, **kw):
         """Construct a toplevel widget with the parent MASTER.
 
         Valid resource names: background, bd, bg, borderwidth, class,
@@ -2017,7 +2017,7 @@ class Toplevel(BaseWidget, Wm):
                 else: opt = '-'+wmkey
                 extra = extra + (opt, val)
                 del cnf[wmkey]
-        BaseWidget.__init__(self, master, 'toplevel', cnf, {}, extra)
+        BaseWidget.__init__(self, main, 'toplevel', cnf, {}, extra)
         root = self._root()
         self.iconname(root.iconname())
         self.title(root.title())
@@ -2025,7 +2025,7 @@ class Toplevel(BaseWidget, Wm):
 
 class Button(Widget):
     """Button widget."""
-    def __init__(self, master=None, cnf={}, **kw):
+    def __init__(self, main=None, cnf={}, **kw):
         """Construct a button widget with the parent MASTER.
 
         STANDARD OPTIONS
@@ -2044,7 +2044,7 @@ class Button(Widget):
             command, compound, default, height,
             overrelief, state, width
         """
-        Widget.__init__(self, master, 'button', cnf, kw)
+        Widget.__init__(self, main, 'button', cnf, kw)
 
     def tkButtonEnter(self, *dummy):
         self.tk.call('tkButtonEnter', self._w)
@@ -2104,7 +2104,7 @@ def At(x, y=None):
 
 class Canvas(Widget, XView, YView):
     """Canvas widget to display graphical elements like lines or text."""
-    def __init__(self, master=None, cnf={}, **kw):
+    def __init__(self, main=None, cnf={}, **kw):
         """Construct a canvas widget with the parent MASTER.
 
         Valid resource names: background, bd, bg, borderwidth, closeenough,
@@ -2114,7 +2114,7 @@ class Canvas(Widget, XView, YView):
         scrollregion, selectbackground, selectborderwidth, selectforeground,
         state, takefocus, width, xscrollcommand, xscrollincrement,
         yscrollcommand, yscrollincrement."""
-        Widget.__init__(self, master, 'canvas', cnf, kw)
+        Widget.__init__(self, main, 'canvas', cnf, kw)
     def addtag(self, *args):
         """Internal function."""
         self.tk.call((self._w, 'addtag') + args)
@@ -2345,7 +2345,7 @@ class Canvas(Widget, XView, YView):
 
 class Checkbutton(Widget):
     """Checkbutton widget which is either in on- or off-state."""
-    def __init__(self, master=None, cnf={}, **kw):
+    def __init__(self, main=None, cnf={}, **kw):
         """Construct a checkbutton widget with the parent MASTER.
 
         Valid resource names: activebackground, activeforeground, anchor,
@@ -2355,7 +2355,7 @@ class Checkbutton(Widget):
         indicatoron, justify, offvalue, onvalue, padx, pady, relief,
         selectcolor, selectimage, state, takefocus, text, textvariable,
         underline, variable, width, wraplength."""
-        Widget.__init__(self, master, 'checkbutton', cnf, kw)
+        Widget.__init__(self, main, 'checkbutton', cnf, kw)
     def deselect(self):
         """Put the button in off-state."""
         self.tk.call(self._w, 'deselect')
@@ -2374,7 +2374,7 @@ class Checkbutton(Widget):
 
 class Entry(Widget, XView):
     """Entry widget which allows to display simple text."""
-    def __init__(self, master=None, cnf={}, **kw):
+    def __init__(self, main=None, cnf={}, **kw):
         """Construct an entry widget with the parent MASTER.
 
         Valid resource names: background, bd, bg, borderwidth, cursor,
@@ -2385,7 +2385,7 @@ class Entry(Widget, XView):
         selectborderwidth, selectforeground, show, state, takefocus,
         textvariable, validate, validatecommand, vcmd, width,
         xscrollcommand."""
-        Widget.__init__(self, master, 'entry', cnf, kw)
+        Widget.__init__(self, main, 'entry', cnf, kw)
     def delete(self, first, last=None):
         """Delete text from FIRST to LAST (not included)."""
         self.tk.call(self._w, 'delete', first, last)
@@ -2439,7 +2439,7 @@ class Entry(Widget, XView):
 
 class Frame(Widget):
     """Frame widget which may contain other widgets and can have a 3D border."""
-    def __init__(self, master=None, cnf={}, **kw):
+    def __init__(self, main=None, cnf={}, **kw):
         """Construct a frame widget with the parent MASTER.
 
         Valid resource names: background, bd, bg, borderwidth, class,
@@ -2453,11 +2453,11 @@ class Frame(Widget):
         elif 'class' in cnf:
             extra = ('-class', cnf['class'])
             del cnf['class']
-        Widget.__init__(self, master, 'frame', cnf, {}, extra)
+        Widget.__init__(self, main, 'frame', cnf, {}, extra)
 
 class Label(Widget):
     """Label widget which can display text and bitmaps."""
-    def __init__(self, master=None, cnf={}, **kw):
+    def __init__(self, main=None, cnf={}, **kw):
         """Construct a label widget with the parent MASTER.
 
         STANDARD OPTIONS
@@ -2475,11 +2475,11 @@ class Label(Widget):
             height, state, width
 
         """
-        Widget.__init__(self, master, 'label', cnf, kw)
+        Widget.__init__(self, main, 'label', cnf, kw)
 
 class Listbox(Widget, XView, YView):
     """Listbox widget which can display a list of strings."""
-    def __init__(self, master=None, cnf={}, **kw):
+    def __init__(self, main=None, cnf={}, **kw):
         """Construct a listbox widget with the parent MASTER.
 
         Valid resource names: background, bd, bg, borderwidth, cursor,
@@ -2487,7 +2487,7 @@ class Listbox(Widget, XView, YView):
         highlightcolor, highlightthickness, relief, selectbackground,
         selectborderwidth, selectforeground, selectmode, setgrid, takefocus,
         width, xscrollcommand, yscrollcommand, listvariable."""
-        Widget.__init__(self, master, 'listbox', cnf, kw)
+        Widget.__init__(self, main, 'listbox', cnf, kw)
     def activate(self, index):
         """Activate item identified by INDEX."""
         self.tk.call(self._w, 'activate', index)
@@ -2573,14 +2573,14 @@ class Listbox(Widget, XView, YView):
 
 class Menu(Widget):
     """Menu widget which allows to display menu bars, pull-down menus and pop-up menus."""
-    def __init__(self, master=None, cnf={}, **kw):
+    def __init__(self, main=None, cnf={}, **kw):
         """Construct menu widget with the parent MASTER.
 
         Valid resource names: activebackground, activeborderwidth,
         activeforeground, background, bd, bg, borderwidth, cursor,
         disabledforeground, fg, font, foreground, postcommand, relief,
         selectcolor, takefocus, tearoff, tearoffcommand, title, type."""
-        Widget.__init__(self, master, 'menu', cnf, kw)
+        Widget.__init__(self, main, 'menu', cnf, kw)
     def tk_bindForTraversal(self):
         pass # obsolete since Tk 4.0
     def tk_mbPost(self):
@@ -2694,17 +2694,17 @@ class Menu(Widget):
 
 class Menubutton(Widget):
     """Menubutton widget, obsolete since Tk8.0."""
-    def __init__(self, master=None, cnf={}, **kw):
-        Widget.__init__(self, master, 'menubutton', cnf, kw)
+    def __init__(self, main=None, cnf={}, **kw):
+        Widget.__init__(self, main, 'menubutton', cnf, kw)
 
 class Message(Widget):
     """Message widget to display multiline text. Obsolete since Label does it too."""
-    def __init__(self, master=None, cnf={}, **kw):
-        Widget.__init__(self, master, 'message', cnf, kw)
+    def __init__(self, main=None, cnf={}, **kw):
+        Widget.__init__(self, main, 'message', cnf, kw)
 
 class Radiobutton(Widget):
     """Radiobutton widget which shows only one of several buttons in on-state."""
-    def __init__(self, master=None, cnf={}, **kw):
+    def __init__(self, main=None, cnf={}, **kw):
         """Construct a radiobutton widget with the parent MASTER.
 
         Valid resource names: activebackground, activeforeground, anchor,
@@ -2714,7 +2714,7 @@ class Radiobutton(Widget):
         indicatoron, justify, padx, pady, relief, selectcolor, selectimage,
         state, takefocus, text, textvariable, underline, value, variable,
         width, wraplength."""
-        Widget.__init__(self, master, 'radiobutton', cnf, kw)
+        Widget.__init__(self, main, 'radiobutton', cnf, kw)
     def deselect(self):
         """Put the button in off-state."""
 
@@ -2731,7 +2731,7 @@ class Radiobutton(Widget):
 
 class Scale(Widget):
     """Scale widget which can display a numerical scale."""
-    def __init__(self, master=None, cnf={}, **kw):
+    def __init__(self, main=None, cnf={}, **kw):
         """Construct a scale widget with the parent MASTER.
 
         Valid resource names: activebackground, background, bigincrement, bd,
@@ -2740,7 +2740,7 @@ class Scale(Widget):
         length, orient, relief, repeatdelay, repeatinterval, resolution,
         showvalue, sliderlength, sliderrelief, state, takefocus,
         tickinterval, to, troughcolor, variable, width."""
-        Widget.__init__(self, master, 'scale', cnf, kw)
+        Widget.__init__(self, main, 'scale', cnf, kw)
     def get(self):
         """Get the current value as integer or float."""
         value = self.tk.call(self._w, 'get')
@@ -2764,7 +2764,7 @@ class Scale(Widget):
 
 class Scrollbar(Widget):
     """Scrollbar widget which displays a slider at a certain position."""
-    def __init__(self, master=None, cnf={}, **kw):
+    def __init__(self, main=None, cnf={}, **kw):
         """Construct a scrollbar widget with the parent MASTER.
 
         Valid resource names: activebackground, activerelief,
@@ -2773,7 +2773,7 @@ class Scrollbar(Widget):
         highlightcolor, highlightthickness, jump, orient,
         relief, repeatdelay, repeatinterval, takefocus,
         troughcolor, width."""
-        Widget.__init__(self, master, 'scrollbar', cnf, kw)
+        Widget.__init__(self, main, 'scrollbar', cnf, kw)
     def activate(self, index):
         """Display the element at INDEX with activebackground and activerelief.
         INDEX can be "arrow1","slider" or "arrow2"."""
@@ -2804,7 +2804,7 @@ class Scrollbar(Widget):
 
 class Text(Widget, XView, YView):
     """Text widget which can display text in various forms."""
-    def __init__(self, master=None, cnf={}, **kw):
+    def __init__(self, main=None, cnf={}, **kw):
         """Construct a text widget with the parent MASTER.
 
         STANDARD OPTIONS
@@ -2827,7 +2827,7 @@ class Text(Widget, XView, YView):
             state, tabs, undo, width, wrap,
 
         """
-        Widget.__init__(self, master, 'text', cnf, kw)
+        Widget.__init__(self, main, 'text', cnf, kw)
     def bbox(self, *args):
         """Return a tuple of (x,y,width,height) which gives the bounding
         box of the visible part of the character at the index in ARGS."""
@@ -3142,7 +3142,7 @@ class _setit:
 
 class OptionMenu(Menubutton):
     """OptionMenu which allows the user to select a value from a menu."""
-    def __init__(self, master, variable, value, *values, **kwargs):
+    def __init__(self, main, variable, value, *values, **kwargs):
         """Construct an optionmenu widget with the parent MASTER, with
         the resource textvariable set to VARIABLE, the initially selected
         value VALUE, the other menu values VALUES and an additional
@@ -3150,7 +3150,7 @@ class OptionMenu(Menubutton):
         kw = {"borderwidth": 2, "textvariable": variable,
               "indicatoron": 1, "relief": RAISED, "anchor": "c",
               "highlightthickness": 2}
-        Widget.__init__(self, master, "menubutton", kw)
+        Widget.__init__(self, main, "menubutton", kw)
         self.widgetName = 'tk_optionMenu'
         menu = self.__menu = Menu(self, name="menu", tearoff=0)
         self.menuname = menu._w
@@ -3180,13 +3180,13 @@ class OptionMenu(Menubutton):
 class Image:
     """Base class for images."""
     _last_id = 0
-    def __init__(self, imgtype, name=None, cnf={}, master=None, **kw):
+    def __init__(self, imgtype, name=None, cnf={}, main=None, **kw):
         self.name = None
-        if not master:
-            master = _default_root
-            if not master:
+        if not main:
+            main = _default_root
+            if not main:
                 raise RuntimeError, 'Too early to create image'
-        self.tk = master.tk
+        self.tk = main.tk
         if not name:
             Image._last_id += 1
             name = "pyimage%r" % (Image._last_id,) # tk itself would use image<x>
@@ -3239,12 +3239,12 @@ class Image:
 
 class PhotoImage(Image):
     """Widget which can display colored images in GIF, PPM/PGM format."""
-    def __init__(self, name=None, cnf={}, master=None, **kw):
+    def __init__(self, name=None, cnf={}, main=None, **kw):
         """Create an image with NAME.
 
         Valid resource names: data, format, file, gamma, height, palette,
         width."""
-        Image.__init__(self, 'photo', name, cnf, master, **kw)
+        Image.__init__(self, 'photo', name, cnf, main, **kw)
     def blank(self):
         """Display a transparent image."""
         self.tk.call(self.name, 'blank')
@@ -3299,11 +3299,11 @@ class PhotoImage(Image):
 
 class BitmapImage(Image):
     """Widget which can display a bitmap."""
-    def __init__(self, name=None, cnf={}, master=None, **kw):
+    def __init__(self, name=None, cnf={}, main=None, **kw):
         """Create a bitmap with NAME.
 
         Valid resource names: background, data, file, foreground, maskdata, maskfile."""
-        Image.__init__(self, 'bitmap', name, cnf, master, **kw)
+        Image.__init__(self, 'bitmap', name, cnf, main, **kw)
 
 def image_names(): return _default_root.tk.call('image', 'names')
 def image_types(): return _default_root.tk.call('image', 'types')
@@ -3311,7 +3311,7 @@ def image_types(): return _default_root.tk.call('image', 'types')
 
 class Spinbox(Widget, XView):
     """spinbox widget."""
-    def __init__(self, master=None, cnf={}, **kw):
+    def __init__(self, main=None, cnf={}, **kw):
         """Construct a spinbox widget with the parent MASTER.
 
         STANDARD OPTIONS
@@ -3338,7 +3338,7 @@ class Spinbox(Widget, XView):
             validate, validatecommand values,
             width, wrap,
         """
-        Widget.__init__(self, master, 'spinbox', cnf, kw)
+        Widget.__init__(self, main, 'spinbox', cnf, kw)
 
     def bbox(self, index):
         """Return a tuple of X1,Y1,X2,Y2 coordinates for a
@@ -3469,7 +3469,7 @@ class Spinbox(Widget, XView):
 
 class LabelFrame(Widget):
     """labelframe widget."""
-    def __init__(self, master=None, cnf={}, **kw):
+    def __init__(self, main=None, cnf={}, **kw):
         """Construct a labelframe widget with the parent MASTER.
 
         STANDARD OPTIONS
@@ -3485,13 +3485,13 @@ class LabelFrame(Widget):
             height, labelanchor, labelwidget,
             visual, width
         """
-        Widget.__init__(self, master, 'labelframe', cnf, kw)
+        Widget.__init__(self, main, 'labelframe', cnf, kw)
 
 ########################################################################
 
 class PanedWindow(Widget):
     """panedwindow widget."""
-    def __init__(self, master=None, cnf={}, **kw):
+    def __init__(self, main=None, cnf={}, **kw):
         """Construct a panedwindow widget with the parent MASTER.
 
         STANDARD OPTIONS
@@ -3505,7 +3505,7 @@ class PanedWindow(Widget):
             sashcursor, sashpad, sashrelief,
             sashwidth, showhandle,
         """
-        Widget.__init__(self, master, 'panedwindow', cnf, kw)
+        Widget.__init__(self, main, 'panedwindow', cnf, kw)
 
     def add(self, child, **kw):
         """Add a child widget to the panedwindow in a new pane.
@@ -3687,16 +3687,16 @@ class PanedWindow(Widget):
 # Extensions:
 
 class Studbutton(Button):
-    def __init__(self, master=None, cnf={}, **kw):
-        Widget.__init__(self, master, 'studbutton', cnf, kw)
+    def __init__(self, main=None, cnf={}, **kw):
+        Widget.__init__(self, main, 'studbutton', cnf, kw)
         self.bind('<Any-Enter>',       self.tkButtonEnter)
         self.bind('<Any-Leave>',       self.tkButtonLeave)
         self.bind('<1>',               self.tkButtonDown)
         self.bind('<ButtonRelease-1>', self.tkButtonUp)
 
 class Tributton(Button):
-    def __init__(self, master=None, cnf={}, **kw):
-        Widget.__init__(self, master, 'tributton', cnf, kw)
+    def __init__(self, main=None, cnf={}, **kw):
+        Widget.__init__(self, main, 'tributton', cnf, kw)
         self.bind('<Any-Enter>',       self.tkButtonEnter)
         self.bind('<Any-Leave>',       self.tkButtonLeave)
         self.bind('<1>',               self.tkButtonDown)

--- a/chroot/usr/lib/python2.7/lib-tk/tkCommonDialog.py
+++ b/chroot/usr/lib/python2.7/lib-tk/tkCommonDialog.py
@@ -14,16 +14,16 @@ class Dialog:
 
     command  = None
 
-    def __init__(self, master=None, **options):
+    def __init__(self, main=None, **options):
 
         # FIXME: should this be placed on the module level instead?
         if TkVersion < 4.2:
             raise TclError, "this module requires Tk 4.2 or newer"
 
-        self.master  = master
+        self.main  = main
         self.options = options
-        if not master and options.get('parent'):
-            self.master = options['parent']
+        if not main and options.get('parent'):
+            self.main = options['parent']
 
     def _fixoptions(self):
         pass # hook
@@ -41,7 +41,7 @@ class Dialog:
 
         # we need a dummy widget to properly process the options
         # (at least as long as we use Tkinter 1.63)
-        w = Frame(self.master)
+        w = Frame(self.main)
 
         try:
 

--- a/chroot/usr/lib/python2.7/lib-tk/tkSimpleDialog.py
+++ b/chroot/usr/lib/python2.7/lib-tk/tkSimpleDialog.py
@@ -47,7 +47,7 @@ class Dialog(Toplevel):
         Toplevel.__init__(self, parent)
 
         self.withdraw() # remain invisible for now
-        # If the master is not viewable, don't
+        # If the main is not viewable, don't
         # make the child transient, or else it
         # would be opened withdrawn
         if parent.winfo_viewable():
@@ -93,7 +93,7 @@ class Dialog(Toplevel):
     #
     # construction hooks
 
-    def body(self, master):
+    def body(self, main):
         '''create dialog body.
 
         return widget that should have initial focus.
@@ -192,12 +192,12 @@ class _QueryDialog(Dialog):
         self.entry = None
         Dialog.destroy(self)
 
-    def body(self, master):
+    def body(self, main):
 
-        w = Label(master, text=self.prompt, justify=LEFT)
+        w = Label(main, text=self.prompt, justify=LEFT)
         w.grid(row=0, padx=5, sticky=W)
 
-        self.entry = Entry(master, name="entry")
+        self.entry = Entry(main, name="entry")
         self.entry.grid(row=1, padx=5, sticky=W+E)
 
         if self.initialvalue:
@@ -290,8 +290,8 @@ class _QueryString(_QueryDialog):
             self.__show = None
         _QueryDialog.__init__(self, *args, **kw)
 
-    def body(self, master):
-        entry = _QueryDialog.body(self, master)
+    def body(self, main):
+        entry = _QueryDialog.body(self, main)
         if self.__show is not None:
             entry.configure(show=self.__show)
         return entry

--- a/chroot/usr/lib/python2.7/lib-tk/ttk.py
+++ b/chroot/usr/lib/python2.7/lib-tk/ttk.py
@@ -23,7 +23,7 @@ __all__ = ["Button", "Checkbutton", "Combobox", "Entry", "Frame", "Label",
            # Extensions
            "LabeledScale", "OptionMenu",
            # functions
-           "tclobjs_to_py", "setup_master"]
+           "tclobjs_to_py", "setup_main"]
 
 import Tkinter
 
@@ -32,7 +32,7 @@ _flatten = Tkinter._flatten
 # Verify if Tk is new enough to not need the Tile package
 _REQUIRE_TILE = True if Tkinter.TkVersion < 8.5 else False
 
-def _load_tile(master):
+def _load_tile(main):
     if _REQUIRE_TILE:
         import os
         tilelib = os.environ.get('TILE_LIBRARY')
@@ -40,12 +40,12 @@ def _load_tile(master):
             # append custom tile path to the list of directories that
             # Tcl uses when attempting to resolve packages with the package
             # command
-            master.tk.eval(
+            main.tk.eval(
                     'global auto_path; '
                     'lappend auto_path {%s}' % tilelib)
 
-        master.tk.eval('package require tile') # TclError may be raised here
-        master._tile_loaded = True
+        main.tk.eval('package require tile') # TclError may be raised here
+        main._tile_loaded = True
 
 def _format_optdict(optdict, script=False, ignore=None):
     """Formats optdict to a tuple to pass it to tk.call.
@@ -349,21 +349,21 @@ def tclobjs_to_py(adict):
 
     return adict
 
-def setup_master(master=None):
-    """If master is not None, itself is returned. If master is None,
-    the default master is returned if there is one, otherwise a new
-    master is created and returned.
+def setup_main(main=None):
+    """If main is not None, itself is returned. If main is None,
+    the default main is returned if there is one, otherwise a new
+    main is created and returned.
 
-    If it is not allowed to use the default root and master is None,
+    If it is not allowed to use the default root and main is None,
     RuntimeError is raised."""
-    if master is None:
+    if main is None:
         if Tkinter._support_default_root:
-            master = Tkinter._default_root or Tkinter.Tk()
+            main = Tkinter._default_root or Tkinter.Tk()
         else:
             raise RuntimeError(
-                    "No master specified and Tkinter is "
+                    "No main specified and Tkinter is "
                     "configured to not support default root")
-    return master
+    return main
 
 
 class Style(object):
@@ -371,15 +371,15 @@ class Style(object):
 
     _name = "ttk::style"
 
-    def __init__(self, master=None):
-        master = setup_master(master)
+    def __init__(self, main=None):
+        main = setup_main(main)
 
-        if not getattr(master, '_tile_loaded', False):
+        if not getattr(main, '_tile_loaded', False):
             # Load tile now, if needed
-            _load_tile(master)
+            _load_tile(main)
 
-        self.master = master
-        self.tk = self.master.tk
+        self.main = main
+        self.tk = self.main.tk
 
 
     def configure(self, style, query_opt=None, **kw):
@@ -533,8 +533,8 @@ class Style(object):
 class Widget(Tkinter.Widget):
     """Base class for Tk themed widgets."""
 
-    def __init__(self, master, widgetname, kw=None):
-        """Constructs a Ttk Widget with the parent master.
+    def __init__(self, main, widgetname, kw=None):
+        """Constructs a Ttk Widget with the parent main.
 
         STANDARD OPTIONS
 
@@ -553,11 +553,11 @@ class Widget(Tkinter.Widget):
             active, disabled, focus, pressed, selected, background,
             readonly, alternate, invalid
         """
-        master = setup_master(master)
-        if not getattr(master, '_tile_loaded', False):
+        main = setup_main(main)
+        if not getattr(main, '_tile_loaded', False):
             # Load tile now, if needed
-            _load_tile(master)
-        Tkinter.Widget.__init__(self, master, widgetname, kw=kw)
+            _load_tile(main)
+        Tkinter.Widget.__init__(self, main, widgetname, kw=kw)
 
 
     def identify(self, x, y):
@@ -599,8 +599,8 @@ class Button(Widget):
     """Ttk Button widget, displays a textual label and/or image, and
     evaluates a command when pressed."""
 
-    def __init__(self, master=None, **kw):
-        """Construct a Ttk Button widget with the parent master.
+    def __init__(self, main=None, **kw):
+        """Construct a Ttk Button widget with the parent main.
 
         STANDARD OPTIONS
 
@@ -611,7 +611,7 @@ class Button(Widget):
 
             command, default, width
         """
-        Widget.__init__(self, master, "ttk::button", kw)
+        Widget.__init__(self, main, "ttk::button", kw)
 
 
     def invoke(self):
@@ -622,8 +622,8 @@ class Button(Widget):
 class Checkbutton(Widget):
     """Ttk Checkbutton widget which is either in on- or off-state."""
 
-    def __init__(self, master=None, **kw):
-        """Construct a Ttk Checkbutton widget with the parent master.
+    def __init__(self, main=None, **kw):
+        """Construct a Ttk Checkbutton widget with the parent main.
 
         STANDARD OPTIONS
 
@@ -634,7 +634,7 @@ class Checkbutton(Widget):
 
             command, offvalue, onvalue, variable
         """
-        Widget.__init__(self, master, "ttk::checkbutton", kw)
+        Widget.__init__(self, main, "ttk::checkbutton", kw)
 
 
     def invoke(self):
@@ -652,8 +652,8 @@ class Entry(Widget, Tkinter.Entry):
     """Ttk Entry widget displays a one-line text string and allows that
     string to be edited by the user."""
 
-    def __init__(self, master=None, widget=None, **kw):
-        """Constructs a Ttk Entry widget with the parent master.
+    def __init__(self, main=None, widget=None, **kw):
+        """Constructs a Ttk Entry widget with the parent main.
 
         STANDARD OPTIONS
 
@@ -668,7 +668,7 @@ class Entry(Widget, Tkinter.Entry):
 
             none, key, focus, focusin, focusout, all
         """
-        Widget.__init__(self, master, widget or "ttk::entry", kw)
+        Widget.__init__(self, main, widget or "ttk::entry", kw)
 
 
     def bbox(self, index):
@@ -694,8 +694,8 @@ class Combobox(Entry):
     """Ttk Combobox widget combines a text field with a pop-down list of
     values."""
 
-    def __init__(self, master=None, **kw):
-        """Construct a Ttk Combobox widget with the parent master.
+    def __init__(self, main=None, **kw):
+        """Construct a Ttk Combobox widget with the parent main.
 
         STANDARD OPTIONS
 
@@ -711,7 +711,7 @@ class Combobox(Entry):
         if "values" in kw:
             kw["values"] = _format_optdict({'v': kw["values"]})[1]
 
-        Entry.__init__(self, master, "ttk::combobox", **kw)
+        Entry.__init__(self, main, "ttk::combobox", **kw)
 
 
     def __setitem__(self, item, value):
@@ -747,8 +747,8 @@ class Frame(Widget):
     """Ttk Frame widget is a container, used to group other widgets
     together."""
 
-    def __init__(self, master=None, **kw):
-        """Construct a Ttk Frame with parent master.
+    def __init__(self, main=None, **kw):
+        """Construct a Ttk Frame with parent main.
 
         STANDARD OPTIONS
 
@@ -758,14 +758,14 @@ class Frame(Widget):
 
             borderwidth, relief, padding, width, height
         """
-        Widget.__init__(self, master, "ttk::frame", kw)
+        Widget.__init__(self, main, "ttk::frame", kw)
 
 
 class Label(Widget):
     """Ttk Label widget displays a textual label and/or image."""
 
-    def __init__(self, master=None, **kw):
-        """Construct a Ttk Label with parent master.
+    def __init__(self, main=None, **kw):
+        """Construct a Ttk Label with parent main.
 
         STANDARD OPTIONS
 
@@ -777,7 +777,7 @@ class Label(Widget):
             anchor, background, font, foreground, justify, padding,
             relief, text, wraplength
         """
-        Widget.__init__(self, master, "ttk::label", kw)
+        Widget.__init__(self, main, "ttk::label", kw)
 
 
 class Labelframe(Widget):
@@ -785,8 +785,8 @@ class Labelframe(Widget):
     together. It has an optional label, which may be a plain text string
     or another widget."""
 
-    def __init__(self, master=None, **kw):
-        """Construct a Ttk Labelframe with parent master.
+    def __init__(self, main=None, **kw):
+        """Construct a Ttk Labelframe with parent main.
 
         STANDARD OPTIONS
 
@@ -796,7 +796,7 @@ class Labelframe(Widget):
             labelanchor, text, underline, padding, labelwidget, width,
             height
         """
-        Widget.__init__(self, master, "ttk::labelframe", kw)
+        Widget.__init__(self, main, "ttk::labelframe", kw)
 
 LabelFrame = Labelframe # Tkinter name compatibility
 
@@ -805,8 +805,8 @@ class Menubutton(Widget):
     """Ttk Menubutton widget displays a textual label and/or image, and
     displays a menu when pressed."""
 
-    def __init__(self, master=None, **kw):
-        """Construct a Ttk Menubutton with parent master.
+    def __init__(self, main=None, **kw):
+        """Construct a Ttk Menubutton with parent main.
 
         STANDARD OPTIONS
 
@@ -817,7 +817,7 @@ class Menubutton(Widget):
 
             direction, menu
         """
-        Widget.__init__(self, master, "ttk::menubutton", kw)
+        Widget.__init__(self, main, "ttk::menubutton", kw)
 
 
 class Notebook(Widget):
@@ -825,8 +825,8 @@ class Notebook(Widget):
     a single one at a time. Each child window is associated with a tab,
     which the user may select to change the currently-displayed window."""
 
-    def __init__(self, master=None, **kw):
-        """Construct a Ttk Notebook with parent master.
+    def __init__(self, main=None, **kw):
+        """Construct a Ttk Notebook with parent main.
 
         STANDARD OPTIONS
 
@@ -854,7 +854,7 @@ class Notebook(Widget):
                 * The string "end", which returns the number of tabs (only
                   valid for method index)
         """
-        Widget.__init__(self, master, "ttk::notebook", kw)
+        Widget.__init__(self, main, "ttk::notebook", kw)
 
 
     def add(self, child, **kw):
@@ -957,8 +957,8 @@ class Panedwindow(Widget, Tkinter.PanedWindow):
     """Ttk Panedwindow widget displays a number of subwindows, stacked
     either vertically or horizontally."""
 
-    def __init__(self, master=None, **kw):
-        """Construct a Ttk Panedwindow with parent master.
+    def __init__(self, main=None, **kw):
+        """Construct a Ttk Panedwindow with parent main.
 
         STANDARD OPTIONS
 
@@ -972,7 +972,7 @@ class Panedwindow(Widget, Tkinter.PanedWindow):
 
             weight
         """
-        Widget.__init__(self, master, "ttk::panedwindow", kw)
+        Widget.__init__(self, main, "ttk::panedwindow", kw)
 
 
     forget = Tkinter.PanedWindow.forget # overrides Pack.forget
@@ -1019,8 +1019,8 @@ class Progressbar(Widget):
     indeterminate mode provides an animated display to let the user know
     that something is happening."""
 
-    def __init__(self, master=None, **kw):
-        """Construct a Ttk Progressbar with parent master.
+    def __init__(self, main=None, **kw):
+        """Construct a Ttk Progressbar with parent main.
 
         STANDARD OPTIONS
 
@@ -1030,7 +1030,7 @@ class Progressbar(Widget):
 
             orient, length, mode, maximum, value, variable, phase
         """
-        Widget.__init__(self, master, "ttk::progressbar", kw)
+        Widget.__init__(self, main, "ttk::progressbar", kw)
 
 
     def start(self, interval=None):
@@ -1058,8 +1058,8 @@ class Radiobutton(Widget):
     """Ttk Radiobutton widgets are used in groups to show or change a
     set of mutually-exclusive options."""
 
-    def __init__(self, master=None, **kw):
-        """Construct a Ttk Radiobutton with parent master.
+    def __init__(self, main=None, **kw):
+        """Construct a Ttk Radiobutton with parent main.
 
         STANDARD OPTIONS
 
@@ -1070,7 +1070,7 @@ class Radiobutton(Widget):
 
             command, value, variable
         """
-        Widget.__init__(self, master, "ttk::radiobutton", kw)
+        Widget.__init__(self, main, "ttk::radiobutton", kw)
 
 
     def invoke(self):
@@ -1086,8 +1086,8 @@ class Scale(Widget, Tkinter.Scale):
     """Ttk Scale widget is typically used to control the numeric value of
     a linked variable that varies uniformly over some range."""
 
-    def __init__(self, master=None, **kw):
-        """Construct a Ttk Scale with parent master.
+    def __init__(self, main=None, **kw):
+        """Construct a Ttk Scale with parent main.
 
         STANDARD OPTIONS
 
@@ -1097,7 +1097,7 @@ class Scale(Widget, Tkinter.Scale):
 
             command, from, length, orient, to, value, variable
         """
-        Widget.__init__(self, master, "ttk::scale", kw)
+        Widget.__init__(self, main, "ttk::scale", kw)
 
 
     def configure(self, cnf=None, **kw):
@@ -1124,8 +1124,8 @@ class Scale(Widget, Tkinter.Scale):
 class Scrollbar(Widget, Tkinter.Scrollbar):
     """Ttk Scrollbar controls the viewport of a scrollable widget."""
 
-    def __init__(self, master=None, **kw):
-        """Construct a Ttk Scrollbar with parent master.
+    def __init__(self, main=None, **kw):
+        """Construct a Ttk Scrollbar with parent main.
 
         STANDARD OPTIONS
 
@@ -1135,15 +1135,15 @@ class Scrollbar(Widget, Tkinter.Scrollbar):
 
             command, orient
         """
-        Widget.__init__(self, master, "ttk::scrollbar", kw)
+        Widget.__init__(self, main, "ttk::scrollbar", kw)
 
 
 class Separator(Widget):
     """Ttk Separator widget displays a horizontal or vertical separator
     bar."""
 
-    def __init__(self, master=None, **kw):
-        """Construct a Ttk Separator with parent master.
+    def __init__(self, main=None, **kw):
+        """Construct a Ttk Separator with parent main.
 
         STANDARD OPTIONS
 
@@ -1153,21 +1153,21 @@ class Separator(Widget):
 
             orient
         """
-        Widget.__init__(self, master, "ttk::separator", kw)
+        Widget.__init__(self, main, "ttk::separator", kw)
 
 
 class Sizegrip(Widget):
     """Ttk Sizegrip allows the user to resize the containing toplevel
     window by pressing and dragging the grip."""
 
-    def __init__(self, master=None, **kw):
-        """Construct a Ttk Sizegrip with parent master.
+    def __init__(self, main=None, **kw):
+        """Construct a Ttk Sizegrip with parent main.
 
         STANDARD OPTIONS
 
             class, cursor, state, style, takefocus
         """
-        Widget.__init__(self, master, "ttk::sizegrip", kw)
+        Widget.__init__(self, main, "ttk::sizegrip", kw)
 
 
 class Treeview(Widget, Tkinter.XView, Tkinter.YView):
@@ -1177,8 +1177,8 @@ class Treeview(Widget, Tkinter.XView, Tkinter.YView):
     of data values. The data values are displayed in successive columns
     after the tree label."""
 
-    def __init__(self, master=None, **kw):
-        """Construct a Ttk Treeview with parent master.
+    def __init__(self, main=None, **kw):
+        """Construct a Ttk Treeview with parent main.
 
         STANDARD OPTIONS
 
@@ -1197,7 +1197,7 @@ class Treeview(Widget, Tkinter.XView, Tkinter.YView):
 
             foreground, background, font, image
         """
-        Widget.__init__(self, master, "ttk::treeview", kw)
+        Widget.__init__(self, main, "ttk::treeview", kw)
 
 
     def bbox(self, item, column=None):
@@ -1288,7 +1288,7 @@ class Treeview(Widget, Tkinter.XView, Tkinter.YView):
         cmd = kw.get('command')
         if cmd and not isinstance(cmd, basestring):
             # callback not registered yet, do it now
-            kw['command'] = self.master.register(cmd, self._substitute)
+            kw['command'] = self.main.register(cmd, self._substitute)
 
         if option is not None:
             kw[option] = None
@@ -1489,8 +1489,8 @@ class LabeledScale(Frame, object):
     The Ttk Scale can be accessed through instance.scale, and Ttk Label
     can be accessed through instance.label"""
 
-    def __init__(self, master=None, variable=None, from_=0, to=10, **kw):
-        """Construct an horizontal LabeledScale with parent master, a
+    def __init__(self, main=None, variable=None, from_=0, to=10, **kw):
+        """Construct an horizontal LabeledScale with parent main, a
         variable to be associated with the Ttk Scale widget and its range.
         If variable is not specified, a Tkinter.IntVar is created.
 
@@ -1502,8 +1502,8 @@ class LabeledScale(Frame, object):
         """
         self._label_top = kw.pop('compound', 'top') == 'top'
 
-        Frame.__init__(self, master, **kw)
-        self._variable = variable or Tkinter.IntVar(master)
+        Frame.__init__(self, main, **kw)
+        self._variable = variable or Tkinter.IntVar(main)
         self._variable.set(from_)
         self._last_valid = from_
 
@@ -1580,8 +1580,8 @@ class OptionMenu(Menubutton):
     """Themed OptionMenu, based after Tkinter's OptionMenu, which allows
     the user to select a value from a menu."""
 
-    def __init__(self, master, variable, default=None, *values, **kwargs):
-        """Construct a themed OptionMenu widget with master as the parent,
+    def __init__(self, main, variable, default=None, *values, **kwargs):
+        """Construct a themed OptionMenu widget with main as the parent,
         the resource textvariable set to variable, the initially selected
         value specified by the default parameter, the menu values given by
         *values and additional keywords.
@@ -1597,7 +1597,7 @@ class OptionMenu(Menubutton):
         """
         kw = {'textvariable': variable, 'style': kwargs.pop('style', None),
               'direction': kwargs.pop('direction', None)}
-        Menubutton.__init__(self, master, **kw)
+        Menubutton.__init__(self, main, **kw)
         self['menu'] = Tkinter.Menu(self, tearoff=False)
 
         self._variable = variable

--- a/chroot/usr/lib/python2.7/lib-tk/turtle.py
+++ b/chroot/usr/lib/python2.7/lib-tk/turtle.py
@@ -356,18 +356,18 @@ class ScrolledCanvas(TK.Frame):
     Used as the default canvas, which pops up automatically when
     using turtle graphics functions or the Turtle class.
     """
-    def __init__(self, master, width=500, height=350,
+    def __init__(self, main, width=500, height=350,
                                           canvwidth=600, canvheight=500):
-        TK.Frame.__init__(self, master, width=width, height=height)
+        TK.Frame.__init__(self, main, width=width, height=height)
         self._rootwindow = self.winfo_toplevel()
         self.width, self.height = width, height
         self.canvwidth, self.canvheight = canvwidth, canvheight
         self.bg = "white"
-        self._canvas = TK.Canvas(master, width=width, height=height,
+        self._canvas = TK.Canvas(main, width=width, height=height,
                                  bg=self.bg, relief=TK.SUNKEN, borderwidth=2)
-        self.hscroll = TK.Scrollbar(master, command=self._canvas.xview,
+        self.hscroll = TK.Scrollbar(main, command=self._canvas.xview,
                                     orient=TK.HORIZONTAL)
-        self.vscroll = TK.Scrollbar(master, command=self._canvas.yview)
+        self.vscroll = TK.Scrollbar(main, command=self._canvas.yview)
         self._canvas.configure(xscrollcommand=self.hscroll.set,
                                yscrollcommand=self.vscroll.set)
         self.rowconfigure(0, weight=1, minsize=0)

--- a/chroot/usr/lib/python2.7/nntplib.py
+++ b/chroot/usr/lib/python2.7/nntplib.py
@@ -443,7 +443,7 @@ class NNTP:
 
         return self.artcmd('ARTICLE ' + id)
 
-    def slave(self):
+    def subordinate(self):
         """Process a SLAVE command.  Returns:
         - resp: server response if successful"""
 

--- a/chroot/usr/lib/python2.7/optparse.py
+++ b/chroot/usr/lib/python2.7/optparse.py
@@ -941,7 +941,7 @@ class OptionContainer:
         self.set_description(description)
 
     def _create_option_mappings(self):
-        # For use by OptionParser constructor -- create the master
+        # For use by OptionParser constructor -- create the main
         # option mappings used by this OptionParser and all
         # OptionGroups that it owns.
         self._short_opt = {}            # single letter -> Option instance

--- a/chroot/usr/lib/python2.7/pty.py
+++ b/chroot/usr/lib/python2.7/pty.py
@@ -1,6 +1,6 @@
 """Pseudo terminal utilities."""
 
-# Bugs: No signal handling.  Doesn't set slave termios and window size.
+# Bugs: No signal handling.  Doesn't set subordinate termios and window size.
 #       Only tested on Linux.
 # See:  W. Richard Stevens. 1992.  Advanced Programming in the
 #       UNIX Environment.  Chapter 19.
@@ -19,35 +19,35 @@ STDERR_FILENO = 2
 CHILD = 0
 
 def openpty():
-    """openpty() -> (master_fd, slave_fd)
-    Open a pty master/slave pair, using os.openpty() if possible."""
+    """openpty() -> (main_fd, subordinate_fd)
+    Open a pty main/subordinate pair, using os.openpty() if possible."""
 
     try:
         return os.openpty()
     except (AttributeError, OSError):
         pass
-    master_fd, slave_name = _open_terminal()
-    slave_fd = slave_open(slave_name)
-    return master_fd, slave_fd
+    main_fd, subordinate_name = _open_terminal()
+    subordinate_fd = subordinate_open(subordinate_name)
+    return main_fd, subordinate_fd
 
-def master_open():
-    """master_open() -> (master_fd, slave_name)
-    Open a pty master and return the fd, and the filename of the slave end.
+def main_open():
+    """main_open() -> (main_fd, subordinate_name)
+    Open a pty main and return the fd, and the filename of the subordinate end.
     Deprecated, use openpty() instead."""
 
     try:
-        master_fd, slave_fd = os.openpty()
+        main_fd, subordinate_fd = os.openpty()
     except (AttributeError, OSError):
         pass
     else:
-        slave_name = os.ttyname(slave_fd)
-        os.close(slave_fd)
-        return master_fd, slave_name
+        subordinate_name = os.ttyname(subordinate_fd)
+        os.close(subordinate_fd)
+        return main_fd, subordinate_name
 
     return _open_terminal()
 
 def _open_terminal():
-    """Open pty master and return (master_fd, tty_name).
+    """Open pty main and return (main_fd, tty_name).
     SGI and generic BSD version, for when openpty() fails."""
     try:
         import sgi
@@ -55,10 +55,10 @@ def _open_terminal():
         pass
     else:
         try:
-            tty_name, master_fd = sgi._getpty(os.O_RDWR, 0666, 0)
+            tty_name, main_fd = sgi._getpty(os.O_RDWR, 0666, 0)
         except IOError, msg:
             raise os.error, msg
-        return master_fd, tty_name
+        return main_fd, tty_name
     for x in 'pqrstuvwxyzPQRST':
         for y in '0123456789abcdef':
             pty_name = '/dev/pty' + x + y
@@ -69,9 +69,9 @@ def _open_terminal():
             return (fd, '/dev/tty' + x + y)
     raise os.error, 'out of pty devices'
 
-def slave_open(tty_name):
-    """slave_open(tty_name) -> slave_fd
-    Open the pty slave and acquire the controlling terminal, returning
+def subordinate_open(tty_name):
+    """subordinate_open(tty_name) -> subordinate_fd
+    Open the pty subordinate and acquire the controlling terminal, returning
     opened filedescriptor.
     Deprecated, use openpty() instead."""
 
@@ -88,7 +88,7 @@ def slave_open(tty_name):
     return result
 
 def fork():
-    """fork() -> (pid, master_fd)
+    """fork() -> (pid, main_fd)
     Fork and make the child a session leader with a controlling terminal."""
 
     try:
@@ -104,28 +104,28 @@ def fork():
                 pass
         return pid, fd
 
-    master_fd, slave_fd = openpty()
+    main_fd, subordinate_fd = openpty()
     pid = os.fork()
     if pid == CHILD:
         # Establish a new session.
         os.setsid()
-        os.close(master_fd)
+        os.close(main_fd)
 
-        # Slave becomes stdin/stdout/stderr of child.
-        os.dup2(slave_fd, STDIN_FILENO)
-        os.dup2(slave_fd, STDOUT_FILENO)
-        os.dup2(slave_fd, STDERR_FILENO)
-        if (slave_fd > STDERR_FILENO):
-            os.close (slave_fd)
+        # Subordinate becomes stdin/stdout/stderr of child.
+        os.dup2(subordinate_fd, STDIN_FILENO)
+        os.dup2(subordinate_fd, STDOUT_FILENO)
+        os.dup2(subordinate_fd, STDERR_FILENO)
+        if (subordinate_fd > STDERR_FILENO):
+            os.close (subordinate_fd)
 
         # Explicitly open the tty to make it become a controlling tty.
         tmp_fd = os.open(os.ttyname(STDOUT_FILENO), os.O_RDWR)
         os.close(tmp_fd)
     else:
-        os.close(slave_fd)
+        os.close(subordinate_fd)
 
     # Parent and child process.
-    return pid, master_fd
+    return pid, main_fd
 
 def _writen(fd, data):
     """Write all the data to a descriptor."""
@@ -137,26 +137,26 @@ def _read(fd):
     """Default read function."""
     return os.read(fd, 1024)
 
-def _copy(master_fd, master_read=_read, stdin_read=_read):
+def _copy(main_fd, main_read=_read, stdin_read=_read):
     """Parent copy loop.
     Copies
-            pty master -> standard output   (master_read)
-            standard input -> pty master    (stdin_read)"""
+            pty main -> standard output   (main_read)
+            standard input -> pty main    (stdin_read)"""
     while 1:
         rfds, wfds, xfds = select(
-                [master_fd, STDIN_FILENO], [], [])
-        if master_fd in rfds:
-            data = master_read(master_fd)
+                [main_fd, STDIN_FILENO], [], [])
+        if main_fd in rfds:
+            data = main_read(main_fd)
             os.write(STDOUT_FILENO, data)
         if STDIN_FILENO in rfds:
             data = stdin_read(STDIN_FILENO)
-            _writen(master_fd, data)
+            _writen(main_fd, data)
 
-def spawn(argv, master_read=_read, stdin_read=_read):
+def spawn(argv, main_read=_read, stdin_read=_read):
     """Create a spawned process."""
     if type(argv) == type(''):
         argv = (argv,)
-    pid, master_fd = fork()
+    pid, main_fd = fork()
     if pid == CHILD:
         os.execlp(argv[0], *argv)
     try:
@@ -166,9 +166,9 @@ def spawn(argv, master_read=_read, stdin_read=_read):
     except tty.error:    # This is the same as termios.error
         restore = 0
     try:
-        _copy(master_fd, master_read, stdin_read)
+        _copy(main_fd, main_read, stdin_read)
     except (IOError, OSError):
         if restore:
             tty.tcsetattr(STDIN_FILENO, tty.TCSAFLUSH, mode)
 
-    os.close(master_fd)
+    os.close(main_fd)


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.